### PR TITLE
feat: Add Brave Browser extension management

### DIFF
--- a/.functions
+++ b/.functions
@@ -2,12 +2,12 @@
 
 # Create a new directory and enter it
 function mkd() {
-	mkdir -p "$@" && cd "$_";
+	mkdir -p "$@" && cd "$_" || exit || exit;
 }
 
 # Change working directory to the top-most Finder window location
 function cdf() { # short for `cdfinder`
-	cd "$(osascript -e 'tell app "Finder" to POSIX path of (insertion location as alias)')";
+	cd "$(osascript -e 'tell app "Finder" to POSIX path of (insertion location as alias)')" || exit || exit;
 }
 
 # Create a .tar.gz archive, using `zopfli`, `pigz` or `gzip` for compression
@@ -171,48 +171,75 @@ function tre() {
 }
 
 
-function juca() {
-    # echo "hello param: $1"
+# function juca() {
+#     # echo "hello param: $1"
 
-    # go to folder
-    echo "Navigating to $1"
+#     # go to folder
+#     echo "Navigating to $1"
 
-    pushd $1 >/dev/null
+#     pushd $1 >/dev/null
 
-    echo ""
-    sleep 1
+#     echo ""
+#     sleep 1
 
-    echo "Removing sub-git repo in $1"
-    echo ""
-    echo "bash: rm -rf .git .DS_Store"
+#     echo "Removing sub-git repo in $1"
+#     echo ""
+#     echo "bash: rm -rf .git .DS_Store"
 
-    rm -f .DS_Store
-    rm -rf .git
+#     rm -f .DS_Store
+#     rm -rf .git
 
-    echo ""
-    sleep 1
+#     echo ""
+#     sleep 1
 
-    echo "Navigating back"
-    # go back
+#     echo "Navigating back"
+#     # go back
 
-    popd >/dev/null
+#     popd >/dev/null
 
-    echo ""
-    sleep 1
+#     echo ""
+#     sleep 1
 
-    # # add in playground
-    # echo "git: git add '$1'"
-    # git add "$1"
+#     # # add in playground
+#     # echo "git: git add '$1'"
+#     # git add "$1"
 
-    # echo "git: git cm 'Add $1'"
-    # git cm "Add $1"
+#     # echo "git: git cm 'Add $1'"
+#     # git cm "Add $1"
 
-    # echo "git: git push"
-    # git push
+#     # echo "git: git push"
+#     # git push
 
-    # echo ""
-    # sleep 1
+#     # echo ""
+#     # sleep 1
 
-    echo ""
-    echo "Push completed: $1 pushed to kidchenko/playground"
+#     echo ""
+#     echo "Push completed: $1 pushed to kidchenko/playground"
+# }
+
+
+sync_brave_extensions_to_file() {
+  local brave_base="$HOME/Library/Application Support/BraveSoftware/Brave-Browser"
+  local extensions_file="$1"
+
+  if [[ ! -f "$extensions_file" ]]; then
+    echo "Creating $extensions_file..."
+    touch "$extensions_file"
+  fi
+
+  echo "Scanning installed Brave extensions..."
+
+  # Read extensions.txt into a set (remove comments, trim)
+  existing_ids=$(grep -v '^\s*#' "$extensions_file" | awk '{print $1}' | sort | uniq)
+
+  # Iterate over each profile Extensions directory
+  find "$brave_base" -maxdepth 2 -type d -name "Extensions" | while read -r ext_dir; do
+    for id in "$ext_dir"/*; do
+      id=$(basename "$id")
+      if ! echo "$existing_ids" | grep -q "^$id$"; then
+        echo "$id  # auto-added" >> "$extensions_file"
+        echo "➕ Added: $id"
+      fi
+    done
+  done
 }

--- a/brave/extensions.txt
+++ b/brave/extensions.txt
@@ -1,12 +1,6 @@
 # Brave/Chrome Extensions List
 # Add one extension ID per line. Inline comments after the ID are allowed.
 
-cjpalhdlnbpafiamejdnhcphjbkeiagm # uBlock Origin - An efficient blocker: easy on CPU and memory.
-gcbommkclmclpchllfjekcdonpmejbdp # Privacy Badger - Protects you from trackers as you browse the web.
-gighmmpiobklfepjocnamgkkbiglidom # Bitwarden - Free Password Manager
-# pdnfnkhpgegpcingjbfihlkjeighnddk # Dark Reader - Dark mode for every website. Take care of your eyes, use dark theme for night and daily browsing.
-# Another example:
-#EXTENSION_ID_HERE # Name of Extension
-#もっとコメント
-#日本語コメントもOKです
-# 아이디 # 설명입니다
+aeblfdkhhhdcdjpifhhbdiojplfjncoa # 1Password
+kbfnbcaeplbcioakkpcpgfkobkghlhen # Grammarly
+bdakmnplckeopfghnlpocafcepegjeap # RescueTime

--- a/brave/extensions.txt
+++ b/brave/extensions.txt
@@ -1,0 +1,12 @@
+# Brave/Chrome Extensions List
+# Add one extension ID per line. Inline comments after the ID are allowed.
+
+cjpalhdlnbpafiamejdnhcphjbkeiagm # uBlock Origin - An efficient blocker: easy on CPU and memory.
+gcbommkclmclpchllfjekcdonpmejbdp # Privacy Badger - Protects you from trackers as you browse the web.
+gighmmpiobklfepjocnamgkkbiglidom # Bitwarden - Free Password Manager
+# pdnfnkhpgegpcingjbfihlkjeighnddk # Dark Reader - Dark mode for every website. Take care of your eyes, use dark theme for night and daily browsing.
+# Another example:
+#EXTENSION_ID_HERE # Name of Extension
+#もっとコメント
+#日本語コメントもOKです
+# 아이디 # 설명입니다

--- a/brave/installExtensions.sh
+++ b/brave/installExtensions.sh
@@ -32,7 +32,26 @@ while IFS= read -r line || [[ -n "$line" ]]; do
     continue
   fi
 
+  BRAVE_PROFILE_BASE="$HOME/Library/Application Support/BraveSoftware/Brave-Browser"
+    EXT_FOUND_FLAG="/tmp/brave_ext_found.$$" # temp file per run
+    rm -f "$EXT_FOUND_FLAG"
+
+    find "$BRAVE_PROFILE_BASE" -maxdepth 1 -type d \( -name "Default" -or -name "Profile*" \) | while read -r profile_dir; do
+    if [[ -d "$profile_dir/Extensions/$extension_id" ]]; then
+        echo "Extension $extension_id is already installed in: $profile_dir"
+        touch "$EXT_FOUND_FLAG"
+        break
+    fi
+    done
+
+    if [[ -f "$EXT_FOUND_FLAG" ]]; then
+    rm -f "$EXT_FOUND_FLAG"
+    continue
+    fi
+
   echo "Found extension ID: $extension_id"
+
+
   install_url="https://chrome.google.com/webstore/detail/$extension_id"
 
   echo "Opening install page for $extension_id..."

--- a/brave/installExtensions.sh
+++ b/brave/installExtensions.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# Script to open installation pages for Brave/Chrome extensions
+
+# Get the directory where the script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSIONS_FILE="$SCRIPT_DIR/extensions.txt"
+
+# Check if extensions.txt file exists
+if [ ! -f "$EXTENSIONS_FILE" ]; then
+  echo "Error: Extensions file not found at $EXTENSIONS_FILE"
+  exit 1
+fi
+
+echo "Processing extensions from $EXTENSIONS_FILE..."
+
+# Read the extensions file line by line
+while IFS= read -r line || [[ -n "$line" ]]; do
+  # Trim leading/trailing whitespace
+  trimmed_line=$(echo "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+
+  # Skip empty lines and lines starting with #
+  if [ -z "$trimmed_line" ] || [[ "$trimmed_line" == \#* ]]; then
+    continue
+  fi
+
+  # Extract extension ID (part before any # comment)
+  extension_id=$(echo "$trimmed_line" | awk -F'#' '{print $1}' | sed 's/[[:space:]]*$//')
+
+  # Skip if no valid ID is found after stripping comment
+  if [ -z "$extension_id" ]; then
+    continue
+  fi
+
+  echo "Found extension ID: $extension_id"
+  install_url="https://chrome.google.com/webstore/detail/$extension_id"
+
+  echo "Opening install page for $extension_id..."
+
+  # Check OS and open the URL
+  if [[ "$(uname)" == "Darwin" ]]; then # macOS
+    if command -v open &> /dev/null && open -Ra "Brave Browser"; then
+      open -a "Brave Browser" "$install_url"
+    else
+      echo "Warning: 'Brave Browser' application not found or 'open' command failed. Attempting default browser."
+      open "$install_url" # Fallback to default browser
+    fi
+  elif [[ "$(uname)" == "Linux" ]]; then # Linux
+    # Try to use brave-browser directly if available, as xdg-open might open in a different default browser.
+    if command -v brave-browser &> /dev/null; then
+      brave-browser "$install_url" &
+    elif command -v xdg-open &> /dev/null; then # Fallback to xdg-open
+      xdg-open "$install_url" &
+    else
+      echo "Error: Could not find 'brave-browser' or 'xdg-open' to open the URL on Linux."
+      echo "Please install one of these or open the URL manually: $install_url"
+    fi
+  else
+    echo "Warning: Unsupported OS: $(uname). Please open the URL manually: $install_url"
+  fi
+
+  # Optional: Add a small delay to prevent overwhelming the system or browser
+  # sleep 1
+done < "$EXTENSIONS_FILE"
+
+echo "Finished processing extensions."
+
+# Make the script executable (this line will be run when the file is created by the agent,
+# but it's good practice to include it if the script were manually created)
+# chmod +x "$SCRIPT_DIR/installExtensions.sh"

--- a/config.yaml
+++ b/config.yaml
@@ -39,3 +39,6 @@ post_install_hooks:
     - run_on: [windows, linux, macos]
       command: "echo 'This is a cross-platform command hook from config.yaml'"
       description: "Example cross-platform command hook."
+    - run_on: [linux, macos]
+      script: "./brave/installExtensions.sh"
+      description: "Installs Brave browser extensions by opening their web store pages."


### PR DESCRIPTION
Implements a system to manage and facilitate the installation of Brave Browser extensions across macOS and Linux.

Key changes:
- Adds `brave/extensions.txt` for listing extension IDs with comments.
- Adds `brave/installExtensions.sh` script to parse the list, construct Chrome Web Store URLs, and open them using OS-specific commands (`open -a "Brave Browser"` for macOS, `brave-browser` or `xdg-open` for Linux).
- Integrates this script into the setup process via a post-install hook defined in `config.yaml`, targeting macOS and Linux systems.
- The script attempts to use Brave Browser directly and falls back to system defaults if necessary.