### PR TITLE
🛡️ Sentinel: Fix sensitive data exposure in backup logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-01-30 - Leaking Git Credentials in Logs
+**Vulnerability:** Git remote URLs containing authentication tokens were being logged to plain text files.
+**Learning:** Utilities that aggregate info about git repositories (like backup scripts) often indiscriminately log `git remote get-url`. When users use PATs (Personal Access Tokens) in URLs, these secrets are leaked.
+**Prevention:** Always sanitize URLs (redact `user:password@`) before logging or displaying them.

--- a/tools/backup-projects.sh
+++ b/tools/backup-projects.sh
@@ -274,13 +274,17 @@ sync_git_repos() {
             local remote_url
             remote_url=$(git -C "$repo_dir" remote get-url origin 2>/dev/null || echo "no remote")
 
+            # Sanitize remote URL for logging (remove credentials)
+            local safe_remote_url
+            safe_remote_url=$(echo "$remote_url" | sed 's|://[^@]*@|://***@|g')
+
             if [[ "$DRY_RUN" == true ]]; then
                 echo -e "  ${BLUE}→${NC} $relative_path"
-                echo -e "    Remote: $remote_url"
+                echo -e "    Remote: $safe_remote_url"
                 debug "Would pull --rebase, commit, and push changes"
             else
                 # Log the repository
-                echo "$relative_path | origin | $remote_url" >> "$git_repos_log"
+                echo "$relative_path | origin | $safe_remote_url" >> "$git_repos_log"
 
                 # Pull latest changes first (rebase to avoid merge commits)
                 if [[ "$remote_url" != "no remote" ]]; then


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix sensitive data exposure in logs

🚨 Severity: HIGH
💡 Vulnerability: Git remote URLs containing authentication tokens (e.g. `https://user:token@github.com/...`) were being logged to plain text files (`git-repos.log`) and printed to stdout.
🎯 Impact: If a user's logs are exposed or if they share their screen/logs, their Personal Access Tokens could be compromised, granting unauthorized access to their repositories.
🔧 Fix: Added a sanitization step using `sed` to mask credentials in the URL (replacing `://user:pass@` with `://***@`) before logging or printing.
✅ Verification: Verified with a reproduction script that creates a dummy repo with a secret in the remote URL, runs the backup script, and confirms the secret is not present in the generated log file.

---
*PR created automatically by Jules for task [6917695432768336272](https://jules.google.com/task/6917695432768336272) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Masked Git credentials in logs and output to prevent accidental exposure of authentication information.

* **Documentation**
  * Added security documentation on credential handling in version control operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->