### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSH private key race condition

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-01-31 - Secure File Creation with 1Password CLI
+**Vulnerability:** Race condition in `tools/setup-ssh-keys.sh` where private keys were written to disk with default permissions before being restricted, exposing them to other users on the system.
+**Learning:** Shell redirection `>` creates files with default umask (often 022/644) before `chmod` can run.
+**Prevention:** Use `(umask 077; command > file)` subshell pattern to ensure sensitive files are created with 0600 permissions atomically.

--- a/tools/setup-ssh-keys.sh
+++ b/tools/setup-ssh-keys.sh
@@ -153,7 +153,9 @@ cmd_restore() {
     chmod 700 "$SSH_DIR"
 
     # Read private key from 1Password and save locally
-    op read "op://$VAULT/$KEY_NAME/private_key" > "$PRIVATE_KEY_FILE"
+    # Use umask 077 to ensure the file is created with 0600 permissions
+    (umask 077; op read "op://$VAULT/$KEY_NAME/private_key" > "$PRIVATE_KEY_FILE")
+    # chmod is redundant if umask worked, but good for clarity/double-check
     chmod 600 "$PRIVATE_KEY_FILE"
 
     # Read public key from 1Password and save locally


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: SSH private keys were written to disk with default permissions (potentially world-readable) before `chmod 600` was applied, creating a race condition window where keys could be compromised.
🎯 Impact: Local attackers could potentially read private keys during restoration.
🔧 Fix: Used `(umask 077; ...)` subshell to ensure files are created with 0600 permissions atomically.
✅ Verification: Verified with reproduction script and code review.

---
*PR created automatically by Jules for task [18171977013562498813](https://jules.google.com/task/18171977013562498813) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH key file creation with proper permission handling to enhance security.

* **Documentation**
  * Added security best practices documentation for SSH key creation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->