### PR TITLE
🛡️ Sentinel: Fix SSH key creation race condition

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-02 - Secure File Creation with Shell Redirection
+**Vulnerability:** SSH private keys restored from 1Password via `op read > file` were created with default umask permissions before `chmod` was applied, creating a race condition.
+**Learning:** Shell redirection creates files before `chmod` can act. Even in "personal" dotfiles, this can expose secrets on multi-user systems (e.g., shared servers).
+**Prevention:** Use `(umask 077 && command > file)` to ensure files are born secure.

--- a/tools/setup-ssh-keys.sh
+++ b/tools/setup-ssh-keys.sh
@@ -149,11 +149,16 @@ cmd_restore() {
     say "Restoring SSH key from 1Password..."
 
     # Create SSH directory
-    mkdir -p "$SSH_DIR"
+    # Use umask to ensure secure permissions on creation
+    (umask 077 && mkdir -p "$SSH_DIR")
     chmod 700 "$SSH_DIR"
 
     # Read private key from 1Password and save locally
-    op read "op://$VAULT/$KEY_NAME/private_key" > "$PRIVATE_KEY_FILE"
+    # Use umask in subshell to prevent race condition where file is briefly group-readable
+    (
+        umask 077
+        op read "op://$VAULT/$KEY_NAME/private_key" > "$PRIVATE_KEY_FILE"
+    )
     chmod 600 "$PRIVATE_KEY_FILE"
 
     # Read public key from 1Password and save locally


### PR DESCRIPTION
🛡️ Sentinel Report:

**Vulnerability:**
Found a race condition in `tools/setup-ssh-keys.sh` where private keys were written to disk using shell redirection (`>`) before permissions were restricted with `chmod`. This created a window where the key was readable by others (depending on system umask).

**Fix:**
Wrapped the file creation and directory creation commands in subshells with `umask 077`.
```bash
(
    umask 077
    op read ... > file
)
```
This ensures the file is created with `-rw-------` permissions from the very first moment.

**Verification:**
Verified using a test script `verify_fix.sh` that files created this way have correct permissions immediately, even when the surrounding environment has a loose umask (0002).

---
*PR created automatically by Jules for task [5195979612076195020](https://jules.google.com/task/5195979612076195020) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SSH key setup vulnerability where private keys could temporarily have insecure file permissions during restoration, creating a potential security race condition on multi-user systems.

* **Documentation**
  * Added security advisory documenting SSH key permission vulnerabilities and recommended best practices for secure file creation to prevent accidental secret exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->