### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSH key creation race condition

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-03 - File Creation Race Conditions
+**Vulnerability:** SSH private keys were created with default umask permissions (world-readable) before being restricted with `chmod`.
+**Learning:** Shell redirection (`>`) creates files with default umask permissions immediately. `chmod` after creation leaves a window of exposure (race condition).
+**Prevention:** Use `umask 077` in a subshell or block before creating sensitive files to ensure they are born secure.

--- a/tools/setup-ssh-keys.sh
+++ b/tools/setup-ssh-keys.sh
@@ -149,11 +149,17 @@ cmd_restore() {
     say "Restoring SSH key from 1Password..."
 
     # Create SSH directory
-    mkdir -p "$SSH_DIR"
+    (
+        umask 077
+        mkdir -p "$SSH_DIR"
+    )
     chmod 700 "$SSH_DIR"
 
     # Read private key from 1Password and save locally
-    op read "op://$VAULT/$KEY_NAME/private_key" > "$PRIVATE_KEY_FILE"
+    (
+        umask 077
+        op read "op://$VAULT/$KEY_NAME/private_key" > "$PRIVATE_KEY_FILE"
+    )
     chmod 600 "$PRIVATE_KEY_FILE"
 
     # Read public key from 1Password and save locally


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: SSH private keys were created with default umask permissions (world-readable) before being restricted with `chmod`. This created a race condition where the key could be read by other users.
🎯 Impact: Potential compromise of SSH private keys if an attacker wins the race condition during key setup/restore.
🔧 Fix: Wrapped file creation in a subshell with `umask 077` to ensure files are born secure (600/700 permissions).
✅ Verification: Verified syntax with `bash -n` and logic by inspection of umask behavior.

---
*PR created automatically by Jules for task [4592572439404520270](https://jules.google.com/task/4592572439404520270) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH key setup to ensure private keys are created with secure permissions from the start, preventing unauthorized access.

* **Documentation**
  * Added security notes documenting file creation best practices for sensitive files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->