### PR TITLE
🛡️ Sentinel: Fix SSH key creation race condition

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-10-24 - Shell Script Race Conditions
+**Vulnerability:** Found a Time-of-Check Time-of-Use (TOCTOU) race condition in `tools/setup-ssh-keys.sh` where a private key was written to disk with default permissions before being restricted with `chmod`.
+**Learning:** Shell scripts often default to permissive `umask` (e.g., 022), making files world-readable for a brief window during creation.
+**Prevention:** Always use `umask 077` in a subshell before writing sensitive files to ensure they are created with restricted permissions (0600) atomically.

--- a/tools/setup-ssh-keys.sh
+++ b/tools/setup-ssh-keys.sh
@@ -152,9 +152,11 @@ cmd_restore() {
     mkdir -p "$SSH_DIR"
     chmod 700 "$SSH_DIR"
 
-    # Read private key from 1Password and save locally
-    op read "op://$VAULT/$KEY_NAME/private_key" > "$PRIVATE_KEY_FILE"
-    chmod 600 "$PRIVATE_KEY_FILE"
+    # Read private key from 1Password and save locally (with secure permissions)
+    (
+        umask 077
+        op read "op://$VAULT/$KEY_NAME/private_key" > "$PRIVATE_KEY_FILE"
+    )
 
     # Read public key from 1Password and save locally
     op read "op://$VAULT/$KEY_NAME/public_key" > "$PUBLIC_KEY_FILE"


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix TOCTOU race condition in SSH key setup

🚨 Severity: CRITICAL
💡 Vulnerability: Time-of-Check Time-of-Use (TOCTOU) race condition where SSH private key was written with default permissions before being restricted.
🎯 Impact: On a multi-user system, an attacker could potentially read the private key during the brief window between file creation and `chmod`.
🔧 Fix: Wrapped the file creation in a subshell with `umask 077` to ensure atomic 0600 permissions.
✅ Verification: Verified syntax with `bash -n` and visual inspection. The `umask 077` guarantees the file is created with read/write access for the owner only.

---
*PR created automatically by Jules for task [13455434870920061545](https://jules.google.com/task/13455434870920061545) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced SSH private key file permission handling during restoration to improve security.

* **Documentation**
  * Added documentation regarding shell script file permission considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->