### PR TITLE
🛡️ Sentinel: Fix TOCTOU vulnerability in SSH key creation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-22 - Secure File Creation in Shell Scripts
+**Vulnerability:** TOCTOU race condition when creating sensitive files (like SSH keys) using redirection (`>`) followed by `chmod`.
+**Learning:** Files created via redirection inherit default permissions (usually 644/666) before `chmod` runs, leaving a window where they are world-readable.
+**Prevention:** Use `umask` inside a subshell to strictly control permissions at creation time: `(umask 077; command > file)`.

--- a/tools/setup-ssh-keys.sh
+++ b/tools/setup-ssh-keys.sh
@@ -153,12 +153,16 @@ cmd_restore() {
     chmod 700 "$SSH_DIR"
 
     # Read private key from 1Password and save locally
-    op read "op://$VAULT/$KEY_NAME/private_key" > "$PRIVATE_KEY_FILE"
-    chmod 600 "$PRIVATE_KEY_FILE"
+    (
+        umask 077
+        op read "op://$VAULT/$KEY_NAME/private_key" > "$PRIVATE_KEY_FILE"
+    )
 
     # Read public key from 1Password and save locally
-    op read "op://$VAULT/$KEY_NAME/public_key" > "$PUBLIC_KEY_FILE"
-    chmod 644 "$PUBLIC_KEY_FILE"
+    (
+        umask 022
+        op read "op://$VAULT/$KEY_NAME/public_key" > "$PUBLIC_KEY_FILE"
+    )
 
     say "SSH key restored to $SSH_DIR"
     echo ""


### PR DESCRIPTION
Fixed a TOCTOU race condition in `tools/setup-ssh-keys.sh` by using `umask` to ensure secure file permissions at creation time. Also added `.jules/sentinel.md` with the learning.

---
*PR created automatically by Jules for task [874749863381477520](https://jules.google.com/task/874749863381477520) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive security guidance on TOCTOU race conditions and best practices for secure file creation procedures to prevent unintended access.

* **Bug Fixes**
  * Enhanced SSH key setup process with explicit permission controls to ensure private and public keys maintain correct access levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->