### PR TITLE
🛡️ Sentinel: Fix TOCTOU race condition in SSH key creation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-22 - TOCTOU Race Condition in File Permissions
+**Vulnerability:** SSH private keys were written to disk with default permissions and then restricted with `chmod` immediately after. This creates a Time-of-Check-Time-of-Use (TOCTOU) race condition window where the file is world-readable (depending on system umask).
+**Learning:** `chmod` is not atomic with file creation. Relying on it for sensitive files leaves a security gap.
+**Prevention:** Use `umask` in a subshell or the `install` command (if portable) to ensure files are created with restrictive permissions from the start. Example: `(umask 077; echo secret > file)`

--- a/tools/setup-ssh-keys.sh
+++ b/tools/setup-ssh-keys.sh
@@ -148,12 +148,20 @@ cmd_restore() {
 
     say "Restoring SSH key from 1Password..."
 
-    # Create SSH directory
-    mkdir -p "$SSH_DIR"
+    # Create SSH directory securely
+    if [[ ! -d "$SSH_DIR" ]]; then
+        (
+            umask 077
+            mkdir -p "$SSH_DIR"
+        )
+    fi
     chmod 700 "$SSH_DIR"
 
-    # Read private key from 1Password and save locally
-    op read "op://$VAULT/$KEY_NAME/private_key" > "$PRIVATE_KEY_FILE"
+    # Read private key from 1Password and save locally securely
+    (
+        umask 077
+        op read "op://$VAULT/$KEY_NAME/private_key" > "$PRIVATE_KEY_FILE"
+    )
     chmod 600 "$PRIVATE_KEY_FILE"
 
     # Read public key from 1Password and save locally


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix TOCTOU race condition in SSH key creation

🚨 Severity: CRITICAL
💡 Vulnerability: SSH private keys were written to disk with default permissions and then restricted with `chmod` immediately after. This creates a Time-of-Check-Time-of-Use (TOCTOU) race condition window where the file is world-readable.
🎯 Impact: Sensitive private keys could be read by other users on the system if they monitor directory changes during the creation window.
🔧 Fix: Wrapped file creation in a subshell with `umask 077` to ensure restrictive permissions are applied at creation time.
✅ Verification: Verified script syntax with `bash -n` and visual inspection of logic.

---
*PR created automatically by Jules for task [9668484018734191816](https://jules.google.com/task/9668484018734191816) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced SSH key creation process with improved file permission handling to ensure restrictive access controls.

* **Documentation**
  * Added documentation on SSH key file permission security best practices and preventative measures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->