### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure private key file creation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-07 - Insecure File Creation for Sensitive Data
+**Vulnerability:** Private SSH keys were created with default umask permissions (often 0644 or 0664) before being restricted to 0600, creating a race condition (TOCTOU) where the file could be read by other users during the creation window.
+**Learning:** Shell redirection (`>`) creates the file before `chmod` is executed, using the process's default umask. Explicitly setting `chmod` afterwards is insufficient for highly sensitive files on multi-user systems.
+**Prevention:** Wrap sensitive file creation commands in a subshell with `umask 077` (or `umask 0177` for executable scripts) to ensure the file is created with restrictive permissions (0600) from the start.

--- a/tools/setup-ssh-keys.sh
+++ b/tools/setup-ssh-keys.sh
@@ -153,7 +153,10 @@ cmd_restore() {
     chmod 700 "$SSH_DIR"
 
     # Read private key from 1Password and save locally
-    op read "op://$VAULT/$KEY_NAME/private_key" > "$PRIVATE_KEY_FILE"
+    (
+        umask 077
+        op read "op://$VAULT/$KEY_NAME/private_key" > "$PRIVATE_KEY_FILE"
+    )
     chmod 600 "$PRIVATE_KEY_FILE"
 
     # Read public key from 1Password and save locally


### PR DESCRIPTION
This PR addresses a critical security vulnerability in `tools/setup-ssh-keys.sh` where private SSH keys were briefly world-readable during creation.

Changes:
- Modified `tools/setup-ssh-keys.sh` to use `umask 077` in a subshell when writing the private key.
- Added `.jules/sentinel.md` to document this security learning.


---
*PR created automatically by Jules for task [3100625607909715068](https://jules.google.com/task/3100625607909715068) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security of SSH key file creation process.

* **Documentation**
  * Added documentation on secure file creation patterns and best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->