### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in SSH key creation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-08 - TOCTOU Race Condition in File Creation
+**Vulnerability:** The SSH private key was being created with default permissions (potentially world-readable) before `chmod 600` was applied. This created a race condition where the key could be read by other users on the system.
+**Learning:** Shell redirection (`>`) creates files with the current `umask` before any subsequent `chmod` command is executed.
+**Prevention:** Use `umask 077` in a subshell when creating sensitive files to ensure they are created with restricted permissions from the start. Example: `(umask 077; command > file)`.

--- a/tools/setup-ssh-keys.sh
+++ b/tools/setup-ssh-keys.sh
@@ -148,12 +148,17 @@ cmd_restore() {
 
     say "Restoring SSH key from 1Password..."
 
-    # Create SSH directory
-    mkdir -p "$SSH_DIR"
+    # Create SSH directory with secure permissions
+    if [[ ! -d "$SSH_DIR" ]]; then
+        mkdir -p -m 700 "$SSH_DIR"
+    fi
     chmod 700 "$SSH_DIR"
 
-    # Read private key from 1Password and save locally
-    op read "op://$VAULT/$KEY_NAME/private_key" > "$PRIVATE_KEY_FILE"
+    # Read private key from 1Password and save locally with secure permissions
+    (
+        umask 077
+        op read "op://$VAULT/$KEY_NAME/private_key" > "$PRIVATE_KEY_FILE"
+    )
     chmod 600 "$PRIVATE_KEY_FILE"
 
     # Read public key from 1Password and save locally


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in SSH key creation

**🚨 Severity:** HIGH
**💡 Vulnerability:** The SSH private key was being created with default permissions (potentially world-readable) before `chmod 600` was applied. This created a Time-of-Check Time-of-Use (TOCTOU) race condition where the key could be read by other users on the system during the window between creation and permission modification.
**🎯 Impact:** An attacker with local access could potentially read the private key during the race condition window, compromising the user's SSH access.
**🔧 Fix:**
1.  Used `(umask 077; command > file)` pattern to ensure the file is created with restricted permissions (`-rw-------`) atomically.
2.  Updated directory creation to use `mkdir -p -m 700` and enforced `chmod 700` even if the directory already exists.
**✅ Verification:**
- Verified the issue with a reproduction script showing default file creation respects `umask` (often 022).
- Verified the fix ensures files are created with 600 permissions immediately.
- Validated script syntax with `bash -n`.

---
*PR created automatically by Jules for task [11977943561005832187](https://jules.google.com/task/11977943561005832187) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced SSH key creation to enforce appropriately restrictive permissions for both private key files and their containing directories.
  * Improved the SSH key restoration process with stricter permission controls during sensitive file creation and handling to better protect key material.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->