### PR TITLE
🛡️ Sentinel: Fix TOCTOU race condition in SSH key setup

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel's Journal
+
+## 2024-05-22 - TOCTOU Race Condition in File Creation
+**Vulnerability:** Found a Time-of-Check to Time-of-Use (TOCTOU) vulnerability in `tools/setup-ssh-keys.sh` where sensitive SSH keys were created with default permissions (potentially world-readable) before being restricted with `chmod`.
+**Learning:** Even with a subsequent `chmod`, there is a small window where a file is accessible to other users on the system if created with default `umask`.
+**Prevention:** Always use `umask 077` in a subshell when creating sensitive files or directories to ensure they are private from the moment of creation.

--- a/tools/setup-ssh-keys.sh
+++ b/tools/setup-ssh-keys.sh
@@ -149,11 +149,16 @@ cmd_restore() {
     say "Restoring SSH key from 1Password..."
 
     # Create SSH directory
-    mkdir -p "$SSH_DIR"
+    if [[ ! -d "$SSH_DIR" ]]; then
+        (umask 077 && mkdir -p "$SSH_DIR")
+    fi
     chmod 700 "$SSH_DIR"
 
     # Read private key from 1Password and save locally
-    op read "op://$VAULT/$KEY_NAME/private_key" > "$PRIVATE_KEY_FILE"
+    (
+        umask 077
+        op read "op://$VAULT/$KEY_NAME/private_key" > "$PRIVATE_KEY_FILE"
+    )
     chmod 600 "$PRIVATE_KEY_FILE"
 
     # Read public key from 1Password and save locally


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix TOCTOU race condition in SSH key setup

🚨 Severity: HIGH
💡 Vulnerability: Time-of-Check to Time-of-Use (TOCTOU) race condition where SSH keys were created with default permissions (potentially world-readable) before being restricted.
🎯 Impact: A malicious local user could potentially read the private key in the brief window between file creation and permission restriction.
🔧 Fix: Wrapped file and directory creation in a subshell with `umask 077` to ensure secure permissions from the moment of creation.
✅ Verification: Verified behavior with a reproduction script and confirmed syntax correctness with `./build.sh`.

---
*PR created automatically by Jules for task [5605279102137415722](https://jules.google.com/task/5605279102137415722) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced SSH key setup process with stricter file and directory permission controls during restoration.

* **Documentation**
  * Added security documentation describing a file permission vulnerability and recommended prevention measures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->