### PR TITLE
🛡️ Sentinel: Fix insecure SSH key creation permissions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel's Journal
+
+## 2025-02-13 - Secure File Creation in Shell Scripts
+**Vulnerability:** SSH private keys were created with default umask (often 022, resulting in 644/world-readable) before being restricted with `chmod 600`. This created a race condition where the key was briefly readable by other users.
+**Learning:** Shell redirection (`>`) and `mkdir` adhere to the process's `umask` at the time of execution. `chmod` after creation leaves a window of vulnerability.
+**Prevention:** Use `(umask 077 && mkdir ...)` for directories and `(umask 077; command > file)` for files to ensure atomic secure permissions. Remove existing files before writing if sensitive to ensure new inode creation with correct permissions.

--- a/tools/setup-ssh-keys.sh
+++ b/tools/setup-ssh-keys.sh
@@ -148,12 +148,21 @@ cmd_restore() {
 
     say "Restoring SSH key from 1Password..."
 
-    # Create SSH directory
-    mkdir -p "$SSH_DIR"
+    # Create SSH directory with secure permissions
+    if [[ ! -d "$SSH_DIR" ]]; then
+        (umask 077 && mkdir -p "$SSH_DIR")
+    fi
     chmod 700 "$SSH_DIR"
 
-    # Read private key from 1Password and save locally
-    op read "op://$VAULT/$KEY_NAME/private_key" > "$PRIVATE_KEY_FILE"
+    # Remove existing files to ensure new files are created with correct permissions
+    rm -f "$PRIVATE_KEY_FILE" "$PUBLIC_KEY_FILE"
+
+    # Read private key from 1Password and save locally with secure permissions
+    # usage of subshell with umask 077 ensures file is created with 600 permissions
+    (
+        umask 077
+        op read "op://$VAULT/$KEY_NAME/private_key" > "$PRIVATE_KEY_FILE"
+    )
     chmod 600 "$PRIVATE_KEY_FILE"
 
     # Read public key from 1Password and save locally


### PR DESCRIPTION
## 🛡️ Sentinel: [CRITICAL/HIGH] Fix Secure SSH Key Creation

**🚨 Severity:** HIGH
**💡 Vulnerability:** Race condition (TOCTOU) in SSH key creation. Private keys were created with default umask permissions (often 644/world-readable) before being restricted with `chmod 600`. This left a brief window where other users on the system could read the private key.
**🎯 Impact:** Potential exposure of private SSH keys to other local users on a shared machine.
**🔧 Fix:**
- Wrapped directory creation `mkdir -p` in a subshell with `umask 077`.
- Wrapped file writing `op read ... > file` in a subshell with `umask 077`.
- Added `rm -f` for existing files to ensure new files are created with correct permissions rather than truncating existing files with potentially insecure permissions.
**✅ Verification:**
- Verified with a test script that files created without `umask` are world-readable, while those created with `(umask 077; ...)` are restricted to owner-only (`600`).
- Verified syntax of the modified script with `bash -n`.


---
*PR created automatically by Jules for task [15876976491062478903](https://jules.google.com/task/15876976491062478903) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new security guide documenting best practices for SSH key file permissions.

* **Bug Fixes**
  * SSH key setup tool enhanced to ensure private keys are created with secure file permissions during the restoration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->