### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in SSH key creation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-22 - SSH Key TOCTOU Vulnerability
+**Vulnerability:** SSH private keys were created with default permissions (likely 644/664) and then chmod'ed to 600, creating a Time-of-Check Time-of-Use (TOCTOU) race condition where the key was briefly world-readable.
+**Learning:** Shell redirection (`>`) creates files with default umask permissions before any subsequent `chmod` command can run.
+**Prevention:** Use `(umask 077 && command > file)` in a subshell to ensure the file is created with restrictive permissions (600) from the very beginning.

--- a/tests/reproduce_issue.sh
+++ b/tests/reproduce_issue.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -e
+
+# Create a temporary directory for the test environment
+TEST_HOME=$(mktemp -d)
+trap 'rm -rf "$TEST_HOME"' EXIT
+
+# Export HOME to point to the temporary directory
+export HOME="$TEST_HOME"
+
+# Also set XDG vars to use temp dir (for safety)
+export XDG_CONFIG_HOME="$TEST_HOME/.config"
+export XDG_DATA_HOME="$TEST_HOME/.local/share"
+export XDG_STATE_HOME="$TEST_HOME/.local/state"
+
+# Setup mock op
+mkdir -p "$TEST_HOME/bin"
+cat > "$TEST_HOME/bin/op" <<'EOF'
+#!/bin/bash
+if [[ "$1" == "account" && "$2" == "list" ]]; then
+    echo "fake-account"
+    exit 0
+fi
+if [[ "$1" == "item" && "$2" == "get" ]]; then
+    exit 0
+fi
+if [[ "$1" == "read" ]]; then
+    echo "fake-key-content"
+    exit 0
+fi
+EOF
+chmod +x "$TEST_HOME/bin/op"
+export PATH="$TEST_HOME/bin:$PATH"
+
+# Setup config
+mkdir -p "$XDG_CONFIG_HOME/dotfiles"
+echo "ssh:" > "$XDG_CONFIG_HOME/dotfiles/config.yaml"
+echo "  vault: test-vault" >> "$XDG_CONFIG_HOME/dotfiles/config.yaml"
+echo "  item_name: test-key" >> "$XDG_CONFIG_HOME/dotfiles/config.yaml"
+
+# Run restore
+# We run the script from the repo root
+./tools/setup-ssh-keys.sh restore
+
+# Verify file exists in the fake home
+if [[ -f "$HOME/.ssh/id_ed25519" ]]; then
+    echo "Key restored successfully to $HOME/.ssh/id_ed25519"
+else
+    echo "Key restore failed"
+    exit 1
+fi

--- a/tools/setup-ssh-keys.sh
+++ b/tools/setup-ssh-keys.sh
@@ -153,7 +153,8 @@ cmd_restore() {
     chmod 700 "$SSH_DIR"
 
     # Read private key from 1Password and save locally
-    op read "op://$VAULT/$KEY_NAME/private_key" > "$PRIVATE_KEY_FILE"
+    # Use umask in subshell to ensure file is created with 600 permissions (preventing TOCTOU race)
+    (umask 077 && op read "op://$VAULT/$KEY_NAME/private_key" > "$PRIVATE_KEY_FILE")
     chmod 600 "$PRIVATE_KEY_FILE"
 
     # Read public key from 1Password and save locally


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: SSH private keys were created with default permissions (644/664) and then chmod'ed to 600, creating a Time-of-Check Time-of-Use (TOCTOU) race condition where the key was briefly world-readable.
🎯 Impact: An attacker could potentially read the private key during the brief window between file creation and chmod.
🔧 Fix: Wrapped the file creation command in a subshell with `umask 077` to ensure the file is created with 600 permissions from the start.
✅ Verification: Added `tests/reproduce_issue.sh` to verify the key creation process works correctly (permissions verified by code inspection as the race is hard to test deterministically).

---
*PR created automatically by Jules for task [10259571738023374831](https://jules.google.com/task/10259571738023374831) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated SSH key restoration process to enhance security
* **Tests**
  * Added comprehensive test script for SSH key restoration
* **Documentation**
  * Added documentation on SSH key creation best practices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->