### PR TITLE
chore(backup): enforce secure permissions and fix arg injection

### DIFF
--- a/tools/backup-projects.sh
+++ b/tools/backup-projects.sh
@@ -232,15 +232,6 @@ parse_args() {
     done
 }
 
-# --- Build Exclude Arguments for Zip ---
-build_exclude_args() {
-    local args=()
-    for pattern in "${EXCLUDE_PATTERNS[@]}"; do
-        args+=("-x" "*/${pattern}/*" "-x" "*/${pattern}")
-    done
-    echo "${args[@]}"
-}
-
 # --- Git Sync ---
 sync_git_repos() {
     say "Syncing git repositories..."
@@ -351,10 +342,12 @@ cmd_backup() {
     # Setup directories
     if [[ "$DRY_RUN" != true ]]; then
         mkdir -p "$BACKUP_TEMP_DIR"
+        chmod 700 "$BACKUP_TEMP_DIR"
         mkdir -p "$LOG_DIR"
+        chmod 700 "$LOG_DIR"
     else
-        debug "Would create: $BACKUP_TEMP_DIR"
-        debug "Would create: $LOG_DIR"
+        debug "Would create: $BACKUP_TEMP_DIR (chmod 700)"
+        debug "Would create: $LOG_DIR (chmod 700)"
     fi
 
     # Sync git repositories first
@@ -406,17 +399,21 @@ cmd_backup() {
             done
         fi
     else
-        local exclude_args
-        exclude_args=$(build_exclude_args)
+        # Build exclude arguments as an array to handle spaces correctly
+        local exclude_args=()
+        for pattern in "${EXCLUDE_PATTERNS[@]}"; do
+            exclude_args+=("-x" "*/${pattern}/*" "-x" "*/${pattern}")
+        done
 
         (
             cd "$HOME" || exit 1
+            # Set umask to ensure archive is not world-readable (0600)
+            umask 077
+
             if [[ "$VERBOSE" == true ]]; then
-                # shellcheck disable=SC2086
-                zip -r "$archive_path" "${relative_paths[@]}" $exclude_args
+                zip -r "$archive_path" "${relative_paths[@]}" "${exclude_args[@]}"
             else
-                # shellcheck disable=SC2086
-                zip -r -q "$archive_path" "${relative_paths[@]}" $exclude_args
+                zip -r -q "$archive_path" "${relative_paths[@]}" "${exclude_args[@]}"
             fi
         )
 
@@ -427,7 +424,7 @@ cmd_backup() {
 
         local archive_size
         archive_size=$(du -h "$archive_path" | cut -f1)
-        say "Archive created: $archive_size"
+        say "Archive created: $archive_size (permissions: 0600)"
     fi
 
     # Upload to remote (only if --upload flag is provided)


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix insecure temporary file creation and argument injection

**Vulnerability:**
The `tools/backup-projects.sh` script created backup directories with default umask permissions, potentially allowing other users on the system to read sensitive source code backups. Additionally, the script constructed zip exclusion arguments as a single string, which could lead to argument injection or failure if patterns contained spaces.

**Impact:**
- Local information disclosure: unauthorized users could read backup contents.
- Potential argument injection or denial of service in backup creation if config contains malicious or complex patterns.

**Fix:**
- Enforce strict permissions (`0700`) on backup directories immediately after creation.
- Set `umask 077` in a subshell before creating the backup zip file to ensure `0600` permissions.
- Refactor exclusion logic to use Bash arrays for safe argument passing.

**Verification:**
- Verified with `tools/backup-projects.sh --dry-run` and custom test script that permissions are correctly set (700 for dir, 600 for file) and spaces in exclusions are handled correctly.
- Validated syntax with `./build.sh syntax`.

---
*PR created automatically by Jules for task [12934425055427575936](https://jules.google.com/task/12934425055427575936) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backup script to enforce restricted permissions on generated archives (0600) and temporary directories (0700).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->