### PR TITLE
🛡️ Sentinel: [MEDIUM] Secure backup file permissions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Secure Backup Permissions
+**Vulnerability:** Backup archives created by `zip` without explicit permissions were world-readable (depending on umask), exposing sensitive project data.
+**Learning:** `mkdir -p` and `zip` respect the process `umask`, but relying on system defaults is insecure for sensitive data.
+**Prevention:** Explicitly set `umask 077` at the start of sensitive operations and use `chmod` to enforce restrictive permissions (600/700) on critical artifacts.

--- a/tests/verify_backup_permissions.sh
+++ b/tests/verify_backup_permissions.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -e
+
+# Setup test paths
+TEST_DIR="$(mktemp -d)"
+TEST_SOURCE="$TEST_DIR/source"
+TEST_BACKUP_DIR="$TEST_DIR/backups"
+TEST_CONFIG="$TEST_DIR/config.yaml"
+SCRIPT_PATH="$(pwd)/tools/backup-projects.sh"
+
+# Cleanup on exit
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+# Create source directory with a file
+mkdir -p "$TEST_SOURCE"
+echo "sensitive data" > "$TEST_SOURCE/secret.txt"
+
+# Create config file
+cat > "$TEST_CONFIG" <<EOF
+backup:
+  folders:
+    - $TEST_SOURCE
+  local:
+    base_dir: $TEST_BACKUP_DIR
+    retention_days: 1
+  remote:
+    enabled: false
+  logging:
+    enabled: false
+EOF
+
+# Make sure script is executable
+chmod +x "$SCRIPT_PATH"
+
+# Run backup script
+"$SCRIPT_PATH" backup --config "$TEST_CONFIG" >/dev/null
+
+# Check backup file permissions
+BACKUP_FILE=$(find "$TEST_BACKUP_DIR" -name "*.zip" | head -n 1)
+
+if [[ -z "$BACKUP_FILE" ]]; then
+    echo "Backup file not found!"
+    exit 1
+fi
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    PERMS=$(stat -f "%Lp" "$BACKUP_FILE")
+    DIR_PERMS=$(stat -f "%Lp" "$TEST_BACKUP_DIR")
+else
+    PERMS=$(stat -c "%a" "$BACKUP_FILE")
+    DIR_PERMS=$(stat -c "%a" "$TEST_BACKUP_DIR")
+fi
+echo "Backup file permissions: $PERMS"
+echo "Backup directory permissions: $DIR_PERMS"
+
+FAILED=0
+
+# Verify if permissions are secure (600 for file, 700 for directory)
+if [[ "$PERMS" != "600" ]]; then
+    echo "FAIL: Backup file permissions are not 600"
+    FAILED=1
+else
+    echo "PASS: Backup file permissions are 600"
+fi
+
+if [[ "$DIR_PERMS" != "700" ]]; then
+    echo "FAIL: Backup directory permissions are not 700"
+    FAILED=1
+else
+    echo "PASS: Backup directory permissions are 700"
+fi
+
+exit $FAILED

--- a/tools/backup-projects.sh
+++ b/tools/backup-projects.sh
@@ -350,7 +350,10 @@ cmd_backup() {
 
     # Setup directories
     if [[ "$DRY_RUN" != true ]]; then
+        # Ensure secure permissions for backup directory (700)
+        umask 077
         mkdir -p "$BACKUP_TEMP_DIR"
+        chmod 700 "$BACKUP_TEMP_DIR"
         mkdir -p "$LOG_DIR"
     else
         debug "Would create: $BACKUP_TEMP_DIR"
@@ -424,6 +427,9 @@ cmd_backup() {
             error "Failed to create archive"
             return 1
         fi
+
+        # Ensure secure permissions for backup archive (600)
+        chmod 600 "$archive_path"
 
         local archive_size
         archive_size=$(du -h "$archive_path" | cut -f1)


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix insecure file permissions on backups

**Vulnerability:** Backup archives created by `tools/backup-projects.sh` relied on default system `umask`, potentially leaving sensitive project backups world-readable (e.g., 644/755).

**Impact:** Local users could read the contents of backup archives, exposing source code, configuration files, and potentially secrets.

**Fix:**
- Added `umask 077` to `cmd_backup` to ensure all created files/directories are private by default.
- Added explicit `chmod 700` to the backup directory.
- Added explicit `chmod 600` to the backup zip archive.

**Verification:**
- Added `tests/verify_backup_permissions.sh` which creates a mock backup and asserts that file permissions are 600 and directory permissions are 700.
- Ran the test script successfully on Linux (assumed environment).


---
*PR created automatically by Jules for task [9963695077044937017](https://jules.google.com/task/9963695077044937017) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Backup archives are now created with secure file permissions, preventing unintended access to sensitive backup data.

* **Tests**
  * Added test validation for backup file and directory permissions across different operating systems.

* **Documentation**
  * Added documentation detailing secure backup permissions best practices and prevention steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->