### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure backup permissions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-21 - Insecure Backup Permissions
+**Vulnerability:** `tools/backup-projects.sh` created project backups with default umask permissions (often 644/755), making them world-readable.
+**Learning:** Scripts generating sensitive artifacts (backups, keys, logs) must explicitly set permissions. Default umask is insufficient for privacy.
+**Prevention:** Enforce `umask 077` at the start of any script that handles sensitive data or artifacts.

--- a/tools/backup-projects.sh
+++ b/tools/backup-projects.sh
@@ -27,6 +27,9 @@
 # Pipestatus
 set -o pipefail
 
+# Set strict permissions for created files/directories (rwx------)
+umask 077
+
 # --- Configuration ---
 CONFIG_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/dotfiles/config.yaml"
 LOG_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/dotfiles"


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix insecure backup permissions

🚨 Severity: MEDIUM
💡 Vulnerability: Project backups were created with default system permissions (often world-readable), potentially exposing sensitive source code.
🎯 Impact: Unauthorized local users could read the contents of backup archives.
🔧 Fix: Enforced `umask 077` at the start of `tools/backup-projects.sh`.
✅ Verification: Verified with a reproduction script that new backups have `-rw-------` permissions.

---
*PR created automatically by Jules for task [230951383663742677](https://jules.google.com/task/230951383663742677) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Backup files are now created with more restrictive permissions, ensuring they are readable and writable only by the owner, preventing unintended access to sensitive data.

* **Documentation**
  * Added security notes documenting backup permission requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->