### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure file permissions in backup script

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-22 - Insecure Default Permissions on Backups
+**Vulnerability:** The `tools/backup-projects.sh` script created zip archives with default permissions (often `644` or `664`), allowing other users on the system to read potentially sensitive project backups.
+**Learning:** Shell scripts using tools like `zip` or `tar` do not automatically restrict permissions of the output file unless `umask` is set.
+**Prevention:** Always set `umask 077` at the beginning of shell scripts that generate sensitive files or directories to ensure they are private by default.

--- a/tests/verify_backup_permissions.sh
+++ b/tests/verify_backup_permissions.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Setup test environment
+PROJECT_DIR="$HOME/kidchenko"
+BACKUP_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/dotfiles/backups"
+BACKUP_DIR="${BACKUP_DIR/#\~/$HOME}" # Expand ~ just in case
+
+# Create dummy project
+mkdir -p "$PROJECT_DIR"
+echo "secret content" > "$PROJECT_DIR/secret.txt"
+
+# Ensure cleanup
+trap 'rm -rf "$PROJECT_DIR"' EXIT
+
+# Run backup script
+# It reads default folders which includes ~/kidchenko
+echo "Running backup script..."
+# Using --verbose to see output, but suppressing standard output unless needed
+if ! bash tools/backup-projects.sh backup --verbose > /tmp/backup_output.log 2>&1; then
+    echo "Backup failed. Output:"
+    cat /tmp/backup_output.log
+    exit 1
+fi
+
+# Find the latest backup
+LATEST_BACKUP=$(ls -t "$BACKUP_DIR"/project-backup-*.zip 2>/dev/null | head -n1)
+
+if [[ -z "$LATEST_BACKUP" ]]; then
+  echo "Error: No backup file created in $BACKUP_DIR"
+  cat /tmp/backup_output.log
+  exit 1
+fi
+
+echo "Backup created: $LATEST_BACKUP"
+
+# Check permissions
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  PERMS=$(stat -f %Lp "$LATEST_BACKUP")
+else
+  PERMS=$(stat -c %a "$LATEST_BACKUP")
+fi
+
+echo "Permissions: $PERMS"
+
+# Cleanup backup file
+rm -f "$LATEST_BACKUP"
+
+# We expect 600 (rw-------)
+if [[ "$PERMS" != "600" ]]; then
+  echo "FAILURE: Permissions are too open ($PERMS). Expected 600."
+  exit 1
+else
+  echo "SUCCESS: Permissions are correct (600)."
+  exit 0
+fi

--- a/tools/backup-projects.sh
+++ b/tools/backup-projects.sh
@@ -27,6 +27,9 @@
 # Pipestatus
 set -o pipefail
 
+# Security: Ensure all created files/directories are private (read/write only by owner)
+umask 077
+
 # --- Configuration ---
 CONFIG_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/dotfiles/config.yaml"
 LOG_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/dotfiles"


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `tools/backup-projects.sh` script created project backup zip files with default system permissions (often 644/664), making them readable by other users on the system.
🎯 Impact: Sensitive project files could be exposed to unauthorized users.
🔧 Fix: Added `umask 077` to the beginning of `tools/backup-projects.sh` to ensure all created files and directories are private (readable/writable only by the owner).
✅ Verification: Added a regression test `tests/verify_backup_permissions.sh` which confirms that created backup files have `600` permissions.

---
*PR created automatically by Jules for task [9275972573300568072](https://jules.google.com/task/9275972573300568072) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a security vulnerability where backup archives were created with overly permissive file permissions, allowing other users to read sensitive data.

* **Tests**
  * Added verification test to ensure backup files are created with restricted file permissions.

* **Documentation**
  * Added security bulletin documenting the backup file permission vulnerability and remediation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->