### PR TITLE
🛡️ Sentinel: [HIGH] Enforce strict permissions on backups

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-23 - Insecure Permissions on Backups
+**Vulnerability:** `tools/backup-projects.sh` created backup zip archives and logs with default umask permissions (often 022/644), making them world-readable on multi-user systems. These backups contain source code and logs contain remote URLs (potentially with tokens).
+**Learning:** Shell scripts creating sensitive files must explicitly manage permissions, as default system umasks are often permissive.
+**Prevention:** Use `umask 077` at the start of scripts handling sensitive data to ensure files are only readable by the owner by default.

--- a/tools/backup-projects.sh
+++ b/tools/backup-projects.sh
@@ -27,6 +27,9 @@
 # Pipestatus
 set -o pipefail
 
+# Security: Ensure backups and logs are only readable by the owner
+umask 077
+
 # --- Configuration ---
 CONFIG_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/dotfiles/config.yaml"
 LOG_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/dotfiles"


### PR DESCRIPTION
Enforce strict file permissions (umask 077) in the backup script to prevent unauthorized access to backup archives and logs.

---
*PR created automatically by Jules for task [18209221158879420013](https://jules.google.com/task/18209221158879420013) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security for backup creation to ensure backup archives and logs are accessible only to the owner, preventing unintended exposure of sensitive information.

* **Documentation**
  * Added security advisory documenting backup permission vulnerabilities and best practices for handling sensitive data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->