### PR TITLE
feat(security): restrict backup file permissions to owner-only

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-24 - Insecure Backup Permissions
+**Vulnerability:** Backup archives created by `tools/backup-projects.sh` were readable by all users on the system (0644 default permissions). These archives contain sensitive project files and potentially secrets.
+**Learning:** Shell scripts using `zip` or `tar` often inherit default umask settings, which are typically permissive. Creating backups in shared environments (even multi-user home machines) requires explicit permission handling.
+**Prevention:** Enforce `umask 0077` (or strict `chmod`) when creating sensitive files or archives in shell scripts. Always assume the default environment is insecure.

--- a/tools/backup-projects.sh
+++ b/tools/backup-projects.sh
@@ -410,6 +410,8 @@ cmd_backup() {
         exclude_args=$(build_exclude_args)
 
         (
+            # Restrict permissions for backup file (owner read/write only)
+            umask 0077
             cd "$HOME" || exit 1
             if [[ "$VERBOSE" == true ]]; then
                 # shellcheck disable=SC2086


### PR DESCRIPTION
Modified tools/backup-projects.sh to enforce umask 0077 when creating backup archives. This ensures that the generated zip files are only readable and writable by the file owner (0600), preventing unauthorized access to potentially sensitive project data in shared environments.

Risk Level: Low
Verification: Manually verified with test case and bash -n syntax check.

---
*PR created automatically by Jules for task [13839611628519565988](https://jules.google.com/task/13839611628519565988) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a security issue where backup archives were created with overly permissive permissions; backups now restrict access to the owner only.

* **Documentation**
  * Added a dated internal guidance entry describing the vulnerability, recommended secure backup practices, and steps to ensure backups are created with strict permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->