### PR TITLE
🛡️ Sentinel: Fix insecure file permissions in backup script

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-25 - Insecure File Permissions in Backup Script
+**Vulnerability:** The `tools/backup-projects.sh` script created backup archives and log directories without explicitly setting restrictive permissions. This meant that on multi-user systems (or even locally if shared), backup archives containing potentially sensitive project code and secrets were readable by other users (group/world readable depending on umask).
+**Learning:** Default umask settings (often 022) are insufficient for security-critical operations like backups. Relying on default permissions assumes a secure environment, which is not always true.
+**Prevention:** Always use `umask 077` in subshells when creating sensitive files or directories. Explicitly `chmod 700` directories and `chmod 600` files after creation to enforce defense-in-depth.

--- a/tools/backup-projects.sh
+++ b/tools/backup-projects.sh
@@ -351,7 +351,9 @@ cmd_backup() {
     # Setup directories
     if [[ "$DRY_RUN" != true ]]; then
         mkdir -p "$BACKUP_TEMP_DIR"
+        chmod 700 "$BACKUP_TEMP_DIR"
         mkdir -p "$LOG_DIR"
+        chmod 700 "$LOG_DIR"
     else
         debug "Would create: $BACKUP_TEMP_DIR"
         debug "Would create: $LOG_DIR"
@@ -411,6 +413,7 @@ cmd_backup() {
 
         (
             cd "$HOME" || exit 1
+            umask 077
             if [[ "$VERBOSE" == true ]]; then
                 # shellcheck disable=SC2086
                 zip -r "$archive_path" "${relative_paths[@]}" $exclude_args
@@ -419,6 +422,8 @@ cmd_backup() {
                 zip -r -q "$archive_path" "${relative_paths[@]}" $exclude_args
             fi
         )
+        # Ensure strict permissions on the archive
+        [[ -f "$archive_path" ]] && chmod 600 "$archive_path"
 
         if [[ ! -f "$archive_path" ]]; then
             error "Failed to create archive"


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix Insecure File Permissions in Backup Script

🚨 Severity: HIGH
💡 Vulnerability: Backup archives containing potentially sensitive project code were created with default umask permissions (often 0644 or 0664), making them readable by other users on the system.
🎯 Impact: Unauthorized users could access project source code, secrets, and configuration files stored in backups.
🔧 Fix:
  - Added `chmod 700` to backup and log directories.
  - Set `umask 077` within the zip creation subshell.
  - Added explicit `chmod 600` to the generated archive file.
✅ Verification:
  - Verified that `mkdir` is followed by `chmod 700`.
  - Verified that `zip` runs under `umask 077`.
  - Verified that the resulting archive is `chmod 600`.

---
*PR created automatically by Jules for task [6173289691338400290](https://jules.google.com/task/6173289691338400290) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a security vulnerability where backup archives and directories could be created with overly permissive access rights on multi-user systems, potentially exposing sensitive backup data.

* **Documentation**
  * Added documentation describing the file permission security issue and recommended preventive measures for backup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->