### PR TITLE
🛡️ Sentinel: Fix insecure backup permissions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-26 - Insecure Backup Permissions
+**Vulnerability:** The backup script `tools/backup-projects.sh` created project archives and log files with default umask permissions (often 644/755), making them readable by other users on the system.
+**Learning:** Shell scripts creating sensitive archives often default to system umask, which is usually designed for collaboration, not secrecy.
+**Prevention:** Explicitly set `umask 077` in a subshell before running archival commands like `zip` or `tar`, and use `chmod 700` on sensitive directories immediately after creation.

--- a/tools/backup-projects.sh
+++ b/tools/backup-projects.sh
@@ -351,7 +351,9 @@ cmd_backup() {
     # Setup directories
     if [[ "$DRY_RUN" != true ]]; then
         mkdir -p "$BACKUP_TEMP_DIR"
+        chmod 700 "$BACKUP_TEMP_DIR"
         mkdir -p "$LOG_DIR"
+        chmod 700 "$LOG_DIR"
     else
         debug "Would create: $BACKUP_TEMP_DIR"
         debug "Would create: $LOG_DIR"
@@ -410,6 +412,7 @@ cmd_backup() {
         exclude_args=$(build_exclude_args)
 
         (
+            umask 077
             cd "$HOME" || exit 1
             if [[ "$VERBOSE" == true ]]; then
                 # shellcheck disable=SC2086


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Backup archives and logs were created with default umask permissions (often 644/755), allowing other users on the system to read potentially sensitive project code and logs.
🎯 Impact: Information disclosure of private repositories, API keys in code, and remote URLs.
🔧 Fix: Enforced chmod 700 on backup/log directories and umask 077 during zip creation.
✅ Verification: Verified that new backup files are created with -rw------- and directories with drwx------.

---
*PR created automatically by Jules for task [3768380392851558610](https://jules.google.com/task/3768380392851558610) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security Fixes**
  * Enhanced backup script with more restrictive permissions for temporary and log directories
  * Backup archives now created with stricter default file permissions

* **Documentation**
  * Added security documentation detailing backup permissions protection and prevention measures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->