### PR TITLE
🛡️ Sentinel: [MEDIUM] Enforce secure file permissions on backup archives and directories

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+## 2025-01-20 - [Insecure File Permissions on Unencrypted Backups]
+**Vulnerability:** The `tools/backup-projects.sh` script creates unencrypted zip archives of project folders containing git repositories, which may include sensitive data like tokens or secrets, but doesn't explicitly secure the resulting backup files or the backup directories.
+
+**Learning:** Shell scripts handling sensitive archives need explicit permission management, especially when the default `umask` of the user might be overly permissive (like `0022`), making backups readable by other users on the system.
+
+**Prevention:** Ensure scripts creating sensitive backup archives explicitly use `umask 077` within the creation subshell and explicitly `chmod 700` any created backup directories to restrict read/write access to the file owner only.

--- a/tools/backup-projects.sh
+++ b/tools/backup-projects.sh
@@ -253,6 +253,7 @@ sync_git_repos() {
     # Clear previous log
     if [[ "$DRY_RUN" != true ]]; then
         mkdir -p "$LOG_DIR"
+        chmod 700 "$LOG_DIR"
         echo "# Git Repositories - $(date '+%Y-%m-%d %H:%M:%S')" > "$git_repos_log"
         echo "# Format: folder | remote_name | remote_url" >> "$git_repos_log"
         echo "" >> "$git_repos_log"
@@ -266,8 +267,6 @@ sync_git_repos() {
             [[ -z "$git_dir" ]] && continue
             local repo_dir
             repo_dir=$(dirname "$git_dir")
-            local repo_name
-            repo_name=$(basename "$repo_dir")
             local relative_path="${repo_dir#$HOME/}"
 
             # Get remote origin URL
@@ -303,7 +302,8 @@ sync_git_repos() {
                     git -C "$repo_dir" add -A 2>/dev/null
 
                     # Commit with auto-generated message
-                    local commit_msg="chore: auto-backup commit $(date '+%Y-%m-%d %H:%M')"
+                    local commit_msg
+                    commit_msg="chore: auto-backup commit $(date '+%Y-%m-%d %H:%M')"
                     if git -C "$repo_dir" commit -m "$commit_msg" 2>/dev/null; then
                         echo -e "    ${GREEN}✓${NC} Committed changes"
                     else
@@ -351,7 +351,9 @@ cmd_backup() {
     # Setup directories
     if [[ "$DRY_RUN" != true ]]; then
         mkdir -p "$BACKUP_TEMP_DIR"
+        chmod 700 "$BACKUP_TEMP_DIR"
         mkdir -p "$LOG_DIR"
+        chmod 700 "$LOG_DIR"
     else
         debug "Would create: $BACKUP_TEMP_DIR"
         debug "Would create: $LOG_DIR"
@@ -410,6 +412,7 @@ cmd_backup() {
         exclude_args=$(build_exclude_args)
 
         (
+            umask 077 # Ensure created archive is only readable by owner
             cd "$HOME" || exit 1
             if [[ "$VERBOSE" == true ]]; then
                 # shellcheck disable=SC2086
@@ -611,6 +614,7 @@ cmd_restore() {
         if [[ ! -d "$restore_dir" ]]; then
             say "Creating directory: $restore_dir"
             mkdir -p "$restore_dir"
+            chmod 700 "$restore_dir"
         fi
 
         if unzip -o "$selected_backup" -d "$restore_dir"; then


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Unencrypted backup archives and their parent directories were created without explicit permissions. This means they inherited the user's default `umask` (e.g. `022`), making backups containing sensitive repositories (like `.git` config and tokens) readable by other users on the system.
🎯 Impact: Local privilege escalation / Information Disclosure. Other users with local access could potentially read the backup contents containing sensitive source code or credentials.
🔧 Fix:
- Added `chmod 700` upon creating the backup temp directory, the log directory, and the restore directory.
- Added `umask 077` within the subshell generating the unencrypted `.zip` file so the archive is restricted to read/write by the owner only.
- Made minor shellcheck formatting tweaks to resolve SC2155 and SC2034 while touching the file.
✅ Verification: Ran `./build.sh lint` to confirm no new shell script warnings. Reviewed script logic to ensure `umask` stays isolated in its subshell.

---
*PR created automatically by Jules for task [180460759084632868](https://jules.google.com/task/180460759084632868) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security documentation detailing backup vulnerabilities and recommended protection measures.

* **Security**
  * Improved backup script with restricted file permissions and access controls to better protect backup archives and directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->