### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix predictable temporary file vulnerability in apt.sh

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-03-05 - [Predictable Temporary File Vulnerability in apt.sh]
+**Vulnerability:** A hardcoded temporary file path (`/tmp/yq`) was used for downloading and installing the `yq` binary. This made the script vulnerable to symlink attacks or local privilege escalation if another user created a malicious file at that location beforehand.
+**Learning:** Hardcoding paths in shared directories like `/tmp` within scripts executing with `sudo` is dangerous and exposes systems to exploitation by less privileged users.
+**Prevention:** Always use securely generated random directories with tools like `mktemp -d` when dealing with temporary files, especially in scripts that install system-wide binaries or run with elevated privileges.

--- a/tools/os_installers/apt.sh
+++ b/tools/os_installers/apt.sh
@@ -231,9 +231,11 @@ fi
 echo "Installing yq..."
 if ! command -v yq &> /dev/null; then
     YQ_VERSION="v4.44.6"
-    wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O /tmp/yq
-    sudo mv /tmp/yq /usr/local/bin/yq
+    TEMP_DIR=$(mktemp -d)
+    wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O "$TEMP_DIR/yq"
+    sudo mv "$TEMP_DIR/yq" /usr/local/bin/yq
     sudo chmod +x /usr/local/bin/yq
+    rm -rf "$TEMP_DIR"
 fi
 
 # Install lsd (LSDeluxe)


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `tools/os_installers/apt.sh` script used a predictable, hardcoded temporary file path (`/tmp/yq`) for downloading the `yq` binary before moving it with `sudo`. This allowed a malicious local user to potentially create a symlink or file at that location, leading to local privilege escalation.
🎯 Impact: A local attacker could exploit the TOCTOU (Time of Check to Time of Use) or predictable temporary file to overwrite system files or execute malicious code as root.
🔧 Fix: Replaced the hardcoded path with a securely generated randomized temporary directory using `mktemp -d`, and ensured the directory is cleaned up after moving the binary.
✅ Verification: Ran syntax checks and linting on the modified script to ensure no new errors were introduced. Checked the implementation of `mktemp`. Recorded the vulnerability in `.jules/sentinel.md` as instructed.

---
*PR created automatically by Jules for task [15981808566953819740](https://jules.google.com/task/15981808566953819740) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security in apt.sh installer by replacing hardcoded temporary file paths with dynamically generated secure temporary directories and proper cleanup.

* **Documentation**
  * Added documentation entry detailing temporary path vulnerability risks and recommended prevention strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->