### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded /tmp path vulnerability in apt.sh

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2024-12-19 - Hardcoded temporary paths (`/tmp/`)
+
+**Vulnerability:** A script was downloading `yq` to a fixed path: `/tmp/yq` before changing its permissions and moving it to `/usr/local/bin/yq`. This creates a race condition/symlink attack vulnerability. If an attacker predicts the path and creates a malicious file or symlink at `/tmp/yq` before the download happens, `wget` might overwrite the attacker's file, but `mv` and `chmod` execute with elevated permissions (`sudo`), which allows arbitrary files to be modified, leading to local privilege escalation.
+**Learning:** Hardcoded `/tmp` paths should not be used in shell scripts, especially when downloading or manipulating files with root (`sudo`) privileges.
+**Prevention:** Use a securely generated temporary directory via `mktemp -d` to securely store downloaded or intermediate files, rather than relying on predictable paths like `/tmp/filename`.

--- a/tools/os_installers/apt.sh
+++ b/tools/os_installers/apt.sh
@@ -231,9 +231,11 @@ fi
 echo "Installing yq..."
 if ! command -v yq &> /dev/null; then
     YQ_VERSION="v4.44.6"
-    wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O /tmp/yq
-    sudo mv /tmp/yq /usr/local/bin/yq
+    yq_tmp_dir=$(mktemp -d)
+    wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O "${yq_tmp_dir}/yq"
+    sudo mv "${yq_tmp_dir}/yq" /usr/local/bin/yq
     sudo chmod +x /usr/local/bin/yq
+    rm -rf "${yq_tmp_dir}"
 fi
 
 # Install lsd (LSDeluxe)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Hardcoded `/tmp/yq` path in `tools/os_installers/apt.sh` could lead to a race condition, symlink attack, or local privilege escalation, especially when moving/executing the file with `sudo`.
🎯 Impact: Attackers could inject arbitrary code or replace files during the brief period between downloading `yq` and executing the `sudo mv` / `sudo chmod` commands.
🔧 Fix: Replaced the fixed `/tmp` path with a securely generated directory using `mktemp -d` and ensuring cleanup. Added the incident learning to `.jules/sentinel.md`.
✅ Verification: Ran `./build.sh` which executes Shellcheck on the shell scripts (including `apt.sh`) ensuring syntax and lint checks still pass.

---
*PR created automatically by Jules for task [13224417190175998637](https://jules.google.com/task/13224417190175998637) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security in package installation by using secure temporary directory handling instead of hardcoded paths to reduce vulnerability risks.

* **Documentation**
  * Added documentation entry regarding temporary path security best practices in installation scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->