### PR TITLE
🛡️ Sentinel: [HIGH] Fix insecure temporary file handling

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-03-06 - [Insecure Temporary File Usage in OS Installer]
+**Vulnerability:** A script (`tools/os_installers/apt.sh`) was hardcoding the temporary download path for a binary (`/tmp/yq`) before moving it to its final destination using `sudo mv`.
+**Learning:** Hardcoding paths in shared temporary directories like `/tmp` creates a Time-of-Check to Time-of-Use (TOCTOU) race condition and enables symlink attacks. An attacker could pre-create a symlink at `/tmp/yq` pointing to a sensitive file, causing it to be overwritten or modified when the script executes with elevated privileges (`sudo`).
+**Prevention:** Use `mktemp -d` to securely generate a unique temporary directory for downloads or intermediate files, rather than relying on predictable paths, especially before executing commands with elevated privileges.

--- a/tools/os_installers/apt.sh
+++ b/tools/os_installers/apt.sh
@@ -231,9 +231,11 @@ fi
 echo "Installing yq..."
 if ! command -v yq &> /dev/null; then
     YQ_VERSION="v4.44.6"
-    wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O /tmp/yq
-    sudo mv /tmp/yq /usr/local/bin/yq
+    YQ_TMP_DIR=$(mktemp -d)
+    wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O "$YQ_TMP_DIR/yq"
+    sudo mv "$YQ_TMP_DIR/yq" /usr/local/bin/yq
     sudo chmod +x /usr/local/bin/yq
+    rm -rf "$YQ_TMP_DIR"
 fi
 
 # Install lsd (LSDeluxe)


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: A script (`tools/os_installers/apt.sh`) was hardcoding the temporary download path for a binary (`/tmp/yq`) before moving it to its final destination using `sudo mv`.
🎯 **Impact**: Hardcoding paths in shared temporary directories like `/tmp` creates a Time-of-Check to Time-of-Use (TOCTOU) race condition and enables symlink attacks. An attacker could pre-create a symlink at `/tmp/yq` pointing to a sensitive file, causing it to be overwritten or modified when the script executes with elevated privileges (`sudo`).
🔧 **Fix**: Replaced the hardcoded path with a securely generated directory using `mktemp -d` to handle downloads before moving them with `sudo`. Documented the learning in `.jules/sentinel.md`.
✅ **Verification**: Run `./build.sh lint` to verify that `tools/os_installers/apt.sh` passes linting and syntax checks successfully. Read `.jules/sentinel.md` to confirm the journal entry.

---
*PR created automatically by Jules for task [5261296992179502194](https://jules.google.com/task/5261296992179502194) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security advisory documentation describing insecure temporary file vulnerabilities and mitigation strategies.

* **Bug Fixes**
  * Enhanced OS installer to use secure temporary directories instead of hardcoded paths, reducing TOCTOU race condition and symlink attack risks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->