### PR TITLE
🛡️ Sentinel: [HIGH] Fix Local Privilege Escalation / Symlink Attack in apt.sh

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Predictable Temporary File Path in Sudo Operations
+**Vulnerability:** The script `tools/os_installers/apt.sh` downloaded `yq` to a hardcoded predictable temporary path (`/tmp/yq`) and then moved it using elevated privileges (`sudo mv`). This could be exploited via a symlink attack for local privilege escalation.
+**Learning:** Hardcoded `/tmp/` files used with elevated privileges expose systems to symlink attacks, a pattern observed in the OS installation scripts.
+**Prevention:** Always use securely generated random directories like `mktemp -d` to stage downloaded files before performing elevated operations.

--- a/tools/os_installers/apt.sh
+++ b/tools/os_installers/apt.sh
@@ -231,8 +231,10 @@ fi
 echo "Installing yq..."
 if ! command -v yq &> /dev/null; then
     YQ_VERSION="v4.44.6"
-    wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O /tmp/yq
-    sudo mv /tmp/yq /usr/local/bin/yq
+    TMP_DIR=$(mktemp -d)
+    wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O "$TMP_DIR/yq"
+    sudo mv "$TMP_DIR/yq" /usr/local/bin/yq
+    rm -rf "$TMP_DIR"
     sudo chmod +x /usr/local/bin/yq
 fi
 


### PR DESCRIPTION
🚨 **Severity: HIGH**
💡 **Vulnerability:** The script `tools/os_installers/apt.sh` downloaded `yq` to a hardcoded predictable temporary path (`/tmp/yq`) and then moved it using elevated privileges (`sudo mv`). This could be exploited via a symlink attack for local privilege escalation. 
🎯 **Impact:** A malicious local user could pre-create a symlink or executable at `/tmp/yq`, leading to an attacker-controlled file being placed at `/usr/local/bin/yq` or local privilege escalation via `sudo mv`.
🔧 **Fix:** Replaced hardcoded `/tmp/yq` path with a securely generated random directory using `mktemp -d`. This ensures the temporary path is unpredictable and owned securely by the user before executing the elevated move operation.
✅ **Verification:** Verified that changes pass shellcheck via `./build.sh lint`.

Sentinel Journal entry has also been created to document this learning.

---
*PR created automatically by Jules for task [5093337245990563626](https://jules.google.com/task/5093337245990563626) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a local privilege escalation vulnerability in the package installation process by improving temporary file handling security.

* **Documentation**
  * Added security documentation detailing vulnerability details and mitigation recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->