### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure temporary file usage in apt installer

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-15 - Insecure Temporary File Creation in Installer Script
+**Vulnerability:** Hardcoded temporary file path `/tmp/yq` used before a `sudo mv` operation, which can lead to symlink attacks or arbitrary code execution by local attackers.
+**Learning:** Hardcoding paths in world-writable directories like `/tmp` is dangerous, especially in scripts that escalate privileges (`sudo`). An attacker can exploit this predictable path before the script has a chance to secure it.
+**Prevention:** Always use securely generated random directories (e.g., `mktemp -d`) for temporary files, especially in privileged operations.

--- a/tools/os_installers/apt.sh
+++ b/tools/os_installers/apt.sh
@@ -231,9 +231,11 @@ fi
 echo "Installing yq..."
 if ! command -v yq &> /dev/null; then
     YQ_VERSION="v4.44.6"
-    wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O /tmp/yq
-    sudo mv /tmp/yq /usr/local/bin/yq
+    tmp_dir=$(mktemp -d)
+    wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O "$tmp_dir/yq"
+    sudo mv "$tmp_dir/yq" /usr/local/bin/yq
     sudo chmod +x /usr/local/bin/yq
+    rm -rf "$tmp_dir"
 fi
 
 # Install lsd (LSDeluxe)


### PR DESCRIPTION
The `tools/os_installers/apt.sh` script previously downloaded the `yq` binary to a hardcoded, predictable path (`/tmp/yq`) before using `sudo` to move it. This exposes the system to symlink attacks or arbitrary file overwrite vulnerabilities by local attackers.

This PR updates the script to securely generate a random temporary directory using `mktemp -d`. The `yq` binary is downloaded into this directory, moved securely, and the temporary directory is cleaned up afterward.

A corresponding journal entry detailing this vulnerability and its prevention was also added to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [9798981713892148457](https://jules.google.com/task/9798981713892148457) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installer security by enhancing temporary file management during the installation process to prevent potential vulnerabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->