### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix symlink attack vulnerability in apt installer

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-12 - Prevent Symlink Attacks in Package Installers
+**Vulnerability:** Hardcoded, predictable temporary file paths (e.g., `/tmp/yq`) used prior to `sudo mv` operations for binary installation.
+**Learning:** Malicious local users can create symlinks at predictable `/tmp` locations before an installation script executes. When the elevated script (using `sudo`) writes to or moves from these predictable paths, it can be exploited to overwrite critical system files, leading to privilege escalation or denial of service.
+**Prevention:** Always use `mktemp -d` to create secure, unpredictable temporary directories for downloading or processing files, especially when running with elevated privileges or performing cross-user operations.

--- a/tools/os_installers/apt.sh
+++ b/tools/os_installers/apt.sh
@@ -231,9 +231,11 @@ fi
 echo "Installing yq..."
 if ! command -v yq &> /dev/null; then
     YQ_VERSION="v4.44.6"
-    wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O /tmp/yq
-    sudo mv /tmp/yq /usr/local/bin/yq
+    TMP_DIR=$(mktemp -d)
+    wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O "$TMP_DIR/yq"
+    sudo mv "$TMP_DIR/yq" /usr/local/bin/yq
     sudo chmod +x /usr/local/bin/yq
+    rm -rf "$TMP_DIR"
 fi
 
 # Install lsd (LSDeluxe)


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The script `tools/os_installers/apt.sh` used a hardcoded, predictable temporary file path (`/tmp/yq`) for downloading the `yq` binary before executing `sudo mv` to place it in `/usr/local/bin`. 
🎯 **Impact:** Malicious local users could pre-create a symlink at `/tmp/yq` pointing to a critical system file. When the script executed the `sudo mv` command, it could overwrite the targeted file, potentially leading to local privilege escalation or a denial of service.
🔧 **Fix:** Replaced the predictable path with a securely generated temporary directory using `mktemp -d`. The binary is downloaded inside this safe directory, moved securely, and the temporary directory is cleaned up.
✅ **Verification:** Verified that `shellcheck` runs clean on `apt.sh` and `./build.sh syntax` confirms valid bash. Journaled the learning in `.jules/sentinel.md` to prevent future recurrences.

---
*PR created automatically by Jules for task [16274124836540046494](https://jules.google.com/task/16274124836540046494) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the apt installer to use secure temporary directories for package file handling during installation.

* **Documentation**
  * Added security documentation outlining best practices for installer workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->