### PR TITLE
🛡️ Sentinel: [HIGH] Fix insecure temporary file vulnerability in apt.sh

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Insecure Temporary File Creation in Installers
+**Vulnerability:** The `tools/os_installers/apt.sh` script used hardcoded paths (e.g., `/tmp/yq`) when downloading binaries. This creates a risk for symlink attacks (where an attacker pre-creates the symlink pointing to a sensitive file) and local privilege escalation, especially when executed with `sudo`.
+**Learning:** Hardcoding temporary file paths in shared directories like `/tmp` is insecure. The script was executing elevated commands (`sudo mv`, `sudo chmod`) on predictably-named files, exposing the system to exploitation if a malicious local user anticipated the action.
+**Prevention:** Always use securely generated random directories like `mktemp -d` to handle temporary files during installations or script executions to prevent predictable file paths and symlink attacks.

--- a/tools/os_installers/apt.sh
+++ b/tools/os_installers/apt.sh
@@ -231,9 +231,11 @@ fi
 echo "Installing yq..."
 if ! command -v yq &> /dev/null; then
     YQ_VERSION="v4.44.6"
-    wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O /tmp/yq
-    sudo mv /tmp/yq /usr/local/bin/yq
+    tmp_dir=$(mktemp -d)
+    wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O "${tmp_dir}/yq"
+    sudo mv "${tmp_dir}/yq" /usr/local/bin/yq
     sudo chmod +x /usr/local/bin/yq
+    rm -rf "$tmp_dir"
 fi
 
 # Install lsd (LSDeluxe)


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Hardcoding a predictable file path in `/tmp` (e.g. `/tmp/yq`) for downloading an artifact and then operating on it with elevated privileges (`sudo mv`, `sudo chmod`). This creates a Time-of-Check to Time-of-Use (TOCTOU) vulnerability where a local attacker can execute a symlink attack or manipulate the file during the brief window before it is moved to `/usr/local/bin`, leading to potential local privilege escalation.
🎯 Impact: A malicious local user could overwrite sensitive files on the system or escalate privileges by controlling the file permissions when the installation script applies `sudo chmod +x`.
🔧 Fix: Adopted secure temporary file creation by leveraging `mktemp -d` to create a securely generated, randomly named directory. The download, execution, and cleanup are fully contained within this restricted space, preventing collision and external manipulation.
✅ Verification: Ran syntax checking using `bash -n` via `./build.sh` to confirm no syntax regressions occurred. Evaluated visually that the script creates the temp directory, points the download securely within it, elevates the move successfully, grants execution privileges safely, and cleans up completely. Recorded learnings in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [11643410835997858068](https://jules.google.com/task/11643410835997858068) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security documentation regarding temporary file handling practices.

* **Bug Fixes**
  * Updated installation scripts to use secure temporary file creation methods instead of fixed paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->