### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix predictable temporary file creation in apt.sh

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2025-02-14 - Predictable Temporary File Paths
+
+**Vulnerability:** Predictable temporary file paths (`/tmp/yq`) were used when downloading and installing external binaries, combined with a `sudo` operation (`sudo mv /tmp/yq /usr/local/bin/yq`).
+**Learning:** Hardcoding files in shared directories like `/tmp` makes the system vulnerable to symlink attacks or local privilege escalation. An attacker could preemptively create a symlink at `/tmp/yq` pointing to a critical system file, which `sudo mv` or `sudo chmod` would then inadvertently overwrite or modify.
+**Prevention:** Always use securely generated temporary directories (e.g., `mktemp -d`) for downloading temporary files, and delete them after use.

--- a/tools/os_installers/apt.sh
+++ b/tools/os_installers/apt.sh
@@ -231,9 +231,11 @@ fi
 echo "Installing yq..."
 if ! command -v yq &> /dev/null; then
     YQ_VERSION="v4.44.6"
-    wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O /tmp/yq
-    sudo mv /tmp/yq /usr/local/bin/yq
+    TMP_DIR=$(mktemp -d)
+    wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O "$TMP_DIR/yq"
+    sudo mv "$TMP_DIR/yq" /usr/local/bin/yq
     sudo chmod +x /usr/local/bin/yq
+    rm -rf "$TMP_DIR"
 fi
 
 # Install lsd (LSDeluxe)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Predictable temporary file paths (`/tmp/yq`) were used when downloading and installing the `yq` binary, combined with a `sudo` operation (`sudo mv /tmp/yq /usr/local/bin/yq`).
🎯 Impact: This makes the system vulnerable to symlink attacks or local privilege escalation. An attacker could preemptively create a symlink at `/tmp/yq` pointing to a critical system file, which `sudo mv` or `sudo chmod` would then inadvertently overwrite or modify.
🔧 Fix: Modified `tools/os_installers/apt.sh` to use a securely generated temporary directory (`mktemp -d`) for downloading the file, and then safely clean up the directory after the operation completes.
✅ Verification: Ran the validation suite using `./build.sh` and confirmed the updated syntax passes ShellCheck linting.

---
*PR created automatically by Jules for task [13046874098064884760](https://jules.google.com/task/13046874098064884760) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed security vulnerability in the binary installation process by implementing secure temporary directory handling to prevent symlink attacks and privilege escalation risks.

* **Documentation**
  * Added security advisory documenting temporary file path vulnerabilities associated with downloading and installing external binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->