### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix predictable temp paths in apt.sh

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-20 - [Hardcoded and Predictable Temporary File Paths]
+**Vulnerability:** Use of predictable temporary file paths like `/tmp/yq`, and downloading executables/archives (`go...tar.gz`, `lsd...deb`) into the current working directory.
+**Learning:** These paths can be predicted by an attacker to conduct a symlink attack or file overwriting, especially when operations like `sudo mv /tmp/yq ...` or `sudo dpkg -i ...` are performed, which can lead to local privilege escalation. Downloading to `cwd` can also clutter the directory or overwrite existing files unintentionally.
+**Prevention:** Use `mktemp -d` to securely generate a random, isolated temporary directory for downloading and manipulating files before moving them or installing them.

--- a/tools/os_installers/apt.sh
+++ b/tools/os_installers/apt.sh
@@ -205,10 +205,11 @@ fi
 echo "Installing Go..."
 if ! command -v go &> /dev/null; then
     GO_VERSION="1.23.4"
-    wget "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz"
+    tmp_dir=$(mktemp -d)
+    wget "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -O "${tmp_dir}/go${GO_VERSION}.linux-amd64.tar.gz"
     sudo rm -rf /usr/local/go
-    sudo tar -C /usr/local -xzf "go${GO_VERSION}.linux-amd64.tar.gz"
-    rm "go${GO_VERSION}.linux-amd64.tar.gz"
+    sudo tar -C /usr/local -xzf "${tmp_dir}/go${GO_VERSION}.linux-amd64.tar.gz"
+    rm -rf "${tmp_dir}"
     echo "NOTE: Add 'export PATH=\$PATH:/usr/local/go/bin' to your shell profile"
 fi
 
@@ -231,18 +232,21 @@ fi
 echo "Installing yq..."
 if ! command -v yq &> /dev/null; then
     YQ_VERSION="v4.44.6"
-    wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O /tmp/yq
-    sudo mv /tmp/yq /usr/local/bin/yq
+    tmp_dir=$(mktemp -d)
+    wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O "${tmp_dir}/yq"
+    sudo mv "${tmp_dir}/yq" /usr/local/bin/yq
     sudo chmod +x /usr/local/bin/yq
+    rm -rf "${tmp_dir}"
 fi
 
 # Install lsd (LSDeluxe)
 echo "Installing lsd..."
 if ! command -v lsd &> /dev/null; then
     LSD_VERSION="1.1.5"
-    wget "https://github.com/lsd-rs/lsd/releases/download/v${LSD_VERSION}/lsd_${LSD_VERSION}_amd64.deb"
-    sudo dpkg -i "lsd_${LSD_VERSION}_amd64.deb"
-    rm "lsd_${LSD_VERSION}_amd64.deb"
+    tmp_dir=$(mktemp -d)
+    wget "https://github.com/lsd-rs/lsd/releases/download/v${LSD_VERSION}/lsd_${LSD_VERSION}_amd64.deb" -O "${tmp_dir}/lsd_${LSD_VERSION}_amd64.deb"
+    sudo dpkg -i "${tmp_dir}/lsd_${LSD_VERSION}_amd64.deb"
+    rm -rf "${tmp_dir}"
 fi
 
 # Install Tesseract OCR


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Use of predictable temporary file paths (`/tmp/yq`) and downloading executables/archives into the current working directory in `tools/os_installers/apt.sh`.
🎯 **Impact:** These paths can be predicted by an attacker to conduct a symlink attack or file overwriting, especially when operations like `sudo mv /tmp/yq ...` or `sudo dpkg -i ...` are performed, which can lead to local privilege escalation.
🔧 **Fix:** Replaced hardcoded `/tmp` paths and `cwd` downloads with securely generated isolated temporary directories using `mktemp -d`.
✅ **Verification:** Run `./build.sh` to ensure scripts pass linting (shellcheck). Examine `tools/os_installers/apt.sh` to verify Go, yq, and lsd installations use `tmp_dir=$(mktemp -d)` and that `rm -rf "${tmp_dir}"` cleans up properly.

---
*PR created automatically by Jules for task [1803863750734523242](https://jules.google.com/task/1803863750734523242) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security in installation scripts by using randomized temporary directories instead of predictable paths, reducing vulnerability to symlink attacks and file overwriting exploits.

* **Documentation**
  * Added security advisory documenting temporary file path vulnerability patterns and prevention directives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->