### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix predictable /tmp path and insecure cwd downloads

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - [Predictable /tmp paths & insecure working directory usage]
+**Vulnerability:** The apt.sh script downloaded packages into a predictable location (/tmp/yq) or the current working directory. This creates symlink attack risks (for predictable paths) and risks overwriting existing files or executing attacker-controlled binaries.
+**Learning:** Hardcoded, predictable /tmp paths can be exploited by an unprivileged user by symlinking the path to a sensitive file. Downloading to the current working directory risks writing files where they shouldn't be.
+**Prevention:** Always use securely generated random directories like `mktemp -d` to handle downloads instead of relying on the current working directory or predictable temporary file paths.

--- a/tools/os_installers/apt.sh
+++ b/tools/os_installers/apt.sh
@@ -205,10 +205,11 @@ fi
 echo "Installing Go..."
 if ! command -v go &> /dev/null; then
     GO_VERSION="1.23.4"
-    wget "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz"
+    TMP_DIR=$(mktemp -d)
+    wget -q "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -O "$TMP_DIR/go.tar.gz"
     sudo rm -rf /usr/local/go
-    sudo tar -C /usr/local -xzf "go${GO_VERSION}.linux-amd64.tar.gz"
-    rm "go${GO_VERSION}.linux-amd64.tar.gz"
+    sudo tar -C /usr/local -xzf "$TMP_DIR/go.tar.gz"
+    rm -rf "$TMP_DIR"
     echo "NOTE: Add 'export PATH=\$PATH:/usr/local/go/bin' to your shell profile"
 fi
 
@@ -231,18 +232,21 @@ fi
 echo "Installing yq..."
 if ! command -v yq &> /dev/null; then
     YQ_VERSION="v4.44.6"
-    wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O /tmp/yq
-    sudo mv /tmp/yq /usr/local/bin/yq
+    TMP_DIR=$(mktemp -d)
+    wget -q "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O "$TMP_DIR/yq"
+    sudo mv "$TMP_DIR/yq" /usr/local/bin/yq
     sudo chmod +x /usr/local/bin/yq
+    rm -rf "$TMP_DIR"
 fi
 
 # Install lsd (LSDeluxe)
 echo "Installing lsd..."
 if ! command -v lsd &> /dev/null; then
     LSD_VERSION="1.1.5"
-    wget "https://github.com/lsd-rs/lsd/releases/download/v${LSD_VERSION}/lsd_${LSD_VERSION}_amd64.deb"
-    sudo dpkg -i "lsd_${LSD_VERSION}_amd64.deb"
-    rm "lsd_${LSD_VERSION}_amd64.deb"
+    TMP_DIR=$(mktemp -d)
+    wget -q "https://github.com/lsd-rs/lsd/releases/download/v${LSD_VERSION}/lsd_${LSD_VERSION}_amd64.deb" -O "$TMP_DIR/lsd.deb"
+    sudo dpkg -i "$TMP_DIR/lsd.deb"
+    rm -rf "$TMP_DIR"
 fi
 
 # Install Tesseract OCR
@@ -253,15 +257,16 @@ sudo apt install -y tesseract-ocr
 echo "Installing Composer..."
 if ! command -v composer &> /dev/null; then
     EXPECTED_CHECKSUM="$(php -r 'copy("https://composer.github.io/installer.sig", "php://stdout");')"
-    php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-    ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
+    TMP_DIR=$(mktemp -d)
+    php -r "copy('https://getcomposer.org/installer', '$TMP_DIR/composer-setup.php');"
+    ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', '$TMP_DIR/composer-setup.php');")"
 
     if [ "$EXPECTED_CHECKSUM" = "$ACTUAL_CHECKSUM" ]; then
-        sudo php composer-setup.php --quiet --install-dir=/usr/local/bin --filename=composer
-        rm composer-setup.php
+        sudo php "$TMP_DIR/composer-setup.php" --quiet --install-dir=/usr/local/bin --filename=composer
+        rm -rf "$TMP_DIR"
     else
         >&2 echo 'ERROR: Invalid installer checksum for Composer'
-        rm composer-setup.php
+        rm -rf "$TMP_DIR"
     fi
 fi
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `tools/os_installers/apt.sh` downloaded packages to predictable locations (like `/tmp/yq`) or directly into the current working directory.
🎯 Impact: This creates a vector for local privilege escalation via symlink attacks, and downloading to the CWD risks writing files where they shouldn't be or overwriting critical files.
🔧 Fix: Refactored the script to use securely generated, isolated temporary directories via `mktemp -d` to house all downloaded artifacts. The temporary directories are then safely removed.
✅ Verification: Ran `./build.sh` which executed `shellcheck` (syntax checks) for all project scripts, passing without error for `apt.sh`. Additionally added a `sentinel.md` journal entry detailing this finding and preventative measures.

---
*PR created automatically by Jules for task [15768480330397275714](https://jules.google.com/task/15768480330397275714) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security in package installation flows for Go, yq, lsd, and Composer. Download and extraction operations now use secure temporary directories instead of predictable paths, mitigating risks of symlink attacks and unauthorized file modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->