### PR TITLE
🛡️ Sentinel: [HIGH] Fix insecure downloads in apt.sh

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - Prevented Insecure Downloads in apt.sh
+**Vulnerability:** Predictable temporary paths (e.g. `/tmp/yq`) and writing directly to the current working directory.
+**Learning:** Hardcoding predictible paths and downloading directly to the root/current working directory opens the system to path traversal, privilege escalation, and unintended overwrites if the file is replaced with a malicious artifact or overwritten by another concurrent process.
+**Prevention:** Use `mktemp -d` to generate securely isolated, unique directories before writing any fetched artifacts to disk, and use `rm -rf` to clean them up afterward.

--- a/tools/os_installers/apt.sh
+++ b/tools/os_installers/apt.sh
@@ -205,10 +205,11 @@ fi
 echo "Installing Go..."
 if ! command -v go &> /dev/null; then
     GO_VERSION="1.23.4"
-    wget "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz"
+    TMP_DIR=$(mktemp -d)
+    wget "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -O "$TMP_DIR/go${GO_VERSION}.linux-amd64.tar.gz"
     sudo rm -rf /usr/local/go
-    sudo tar -C /usr/local -xzf "go${GO_VERSION}.linux-amd64.tar.gz"
-    rm "go${GO_VERSION}.linux-amd64.tar.gz"
+    sudo tar -C /usr/local -xzf "$TMP_DIR/go${GO_VERSION}.linux-amd64.tar.gz"
+    rm -rf "$TMP_DIR"
     echo "NOTE: Add 'export PATH=\$PATH:/usr/local/go/bin' to your shell profile"
 fi
 
@@ -231,18 +232,21 @@ fi
 echo "Installing yq..."
 if ! command -v yq &> /dev/null; then
     YQ_VERSION="v4.44.6"
-    wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O /tmp/yq
-    sudo mv /tmp/yq /usr/local/bin/yq
+    TMP_DIR=$(mktemp -d)
+    wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O "$TMP_DIR/yq"
+    sudo mv "$TMP_DIR/yq" /usr/local/bin/yq
     sudo chmod +x /usr/local/bin/yq
+    rm -rf "$TMP_DIR"
 fi
 
 # Install lsd (LSDeluxe)
 echo "Installing lsd..."
 if ! command -v lsd &> /dev/null; then
     LSD_VERSION="1.1.5"
-    wget "https://github.com/lsd-rs/lsd/releases/download/v${LSD_VERSION}/lsd_${LSD_VERSION}_amd64.deb"
-    sudo dpkg -i "lsd_${LSD_VERSION}_amd64.deb"
-    rm "lsd_${LSD_VERSION}_amd64.deb"
+    TMP_DIR=$(mktemp -d)
+    wget "https://github.com/lsd-rs/lsd/releases/download/v${LSD_VERSION}/lsd_${LSD_VERSION}_amd64.deb" -O "$TMP_DIR/lsd_${LSD_VERSION}_amd64.deb"
+    sudo dpkg -i "$TMP_DIR/lsd_${LSD_VERSION}_amd64.deb"
+    rm -rf "$TMP_DIR"
 fi
 
 # Install Tesseract OCR
@@ -252,16 +256,17 @@ sudo apt install -y tesseract-ocr
 # Install PHP Composer
 echo "Installing Composer..."
 if ! command -v composer &> /dev/null; then
+    TMP_DIR=$(mktemp -d)
     EXPECTED_CHECKSUM="$(php -r 'copy("https://composer.github.io/installer.sig", "php://stdout");')"
-    php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-    ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
+    php -r "copy('https://getcomposer.org/installer', '$TMP_DIR/composer-setup.php');"
+    ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', '$TMP_DIR/composer-setup.php');")"
 
     if [ "$EXPECTED_CHECKSUM" = "$ACTUAL_CHECKSUM" ]; then
-        sudo php composer-setup.php --quiet --install-dir=/usr/local/bin --filename=composer
-        rm composer-setup.php
+        sudo php "$TMP_DIR/composer-setup.php" --quiet --install-dir=/usr/local/bin --filename=composer
+        rm -rf "$TMP_DIR"
     else
         >&2 echo 'ERROR: Invalid installer checksum for Composer'
-        rm composer-setup.php
+        rm -rf "$TMP_DIR"
     fi
 fi
 


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `apt.sh` installer script downloaded executable binaries directly to predictable temporary paths like `/tmp/yq` or straight to the current working directory, which opened the system up to path traversal, privilege escalation, and unintended file clobbering by malicious actors or concurrent processes during the OS setup phase.
🎯 **Impact:** If exploited during execution, a local attacker could create malicious symlinks at predictable paths or replace downloaded binaries in the current directory, resulting in arbitrary code execution with potentially elevated privileges since parts of `apt.sh` use `sudo`.
🔧 **Fix:** Changed the download and extraction processes for `yq`, `Go`, `lsd`, and `Composer` in `tools/os_installers/apt.sh` to construct, utilize, and clean up isolated, randomly generated temporary directories using `mktemp -d`. Recorded this security context in the `.jules/sentinel.md` journal.
✅ **Verification:** Verified by executing the full validation suite via `./build.sh` to ensure no syntax issues or build errors were introduced.

---
*PR created automatically by Jules for task [17657335695860221003](https://jules.google.com/task/17657335695860221003) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security of installation tools for Go, yq, lsd, and Composer by preventing downloads to predictable temporary paths or the current working directory. Each installation now uses isolated temporary directories with proper cleanup, reducing exposure to file tampering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->