### PR TITLE
🛡️ Sentinel: [HIGH] Fix local privilege escalation / symlink vulnerability in apt.sh

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - [Secure Temp Downloads in Setup Scripts]
+**Vulnerability:** Shell scripts downloading binaries directly to the current working directory (`wget ... -O file`) or predictable locations like `/tmp/yq` instead of secure temporary directories.
+**Learning:** This is a recurring pattern in OS installer scripts (`apt.sh`) that exposes users to symlink attacks or overwriting unintended files, especially dangerous when using `sudo mv` afterwards.
+**Prevention:** Always use securely generated isolated temporary directories for script downloads: `TMP_DIR=$(mktemp -d)` paired with `trap 'rm -rf "$TMP_DIR"' EXIT`. Never hardcode `/tmp/` paths or download indiscriminately to the current working directory.

--- a/tools/os_installers/apt.sh
+++ b/tools/os_installers/apt.sh
@@ -6,6 +6,10 @@
 # Exit on error
 set -e
 
+# Create a secure temporary directory for downloads
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
 # Ask for the administrator password upfront
 sudo -v
 
@@ -205,10 +209,10 @@ fi
 echo "Installing Go..."
 if ! command -v go &> /dev/null; then
     GO_VERSION="1.23.4"
-    wget "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz"
+    wget "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -O "$TMP_DIR/go${GO_VERSION}.linux-amd64.tar.gz"
     sudo rm -rf /usr/local/go
-    sudo tar -C /usr/local -xzf "go${GO_VERSION}.linux-amd64.tar.gz"
-    rm "go${GO_VERSION}.linux-amd64.tar.gz"
+    sudo tar -C /usr/local -xzf "$TMP_DIR/go${GO_VERSION}.linux-amd64.tar.gz"
+    rm "$TMP_DIR/go${GO_VERSION}.linux-amd64.tar.gz"
     echo "NOTE: Add 'export PATH=\$PATH:/usr/local/go/bin' to your shell profile"
 fi
 
@@ -231,8 +235,8 @@ fi
 echo "Installing yq..."
 if ! command -v yq &> /dev/null; then
     YQ_VERSION="v4.44.6"
-    wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O /tmp/yq
-    sudo mv /tmp/yq /usr/local/bin/yq
+    wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O "$TMP_DIR/yq"
+    sudo mv "$TMP_DIR/yq" /usr/local/bin/yq
     sudo chmod +x /usr/local/bin/yq
 fi
 
@@ -240,9 +244,9 @@ fi
 echo "Installing lsd..."
 if ! command -v lsd &> /dev/null; then
     LSD_VERSION="1.1.5"
-    wget "https://github.com/lsd-rs/lsd/releases/download/v${LSD_VERSION}/lsd_${LSD_VERSION}_amd64.deb"
-    sudo dpkg -i "lsd_${LSD_VERSION}_amd64.deb"
-    rm "lsd_${LSD_VERSION}_amd64.deb"
+    wget "https://github.com/lsd-rs/lsd/releases/download/v${LSD_VERSION}/lsd_${LSD_VERSION}_amd64.deb" -O "$TMP_DIR/lsd_${LSD_VERSION}_amd64.deb"
+    sudo dpkg -i "$TMP_DIR/lsd_${LSD_VERSION}_amd64.deb"
+    rm "$TMP_DIR/lsd_${LSD_VERSION}_amd64.deb"
 fi
 
 # Install Tesseract OCR
@@ -253,15 +257,15 @@ sudo apt install -y tesseract-ocr
 echo "Installing Composer..."
 if ! command -v composer &> /dev/null; then
     EXPECTED_CHECKSUM="$(php -r 'copy("https://composer.github.io/installer.sig", "php://stdout");')"
-    php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-    ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
+    php -r "copy('https://getcomposer.org/installer', '$TMP_DIR/composer-setup.php');"
+    ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', '$TMP_DIR/composer-setup.php');")"
 
     if [ "$EXPECTED_CHECKSUM" = "$ACTUAL_CHECKSUM" ]; then
-        sudo php composer-setup.php --quiet --install-dir=/usr/local/bin --filename=composer
-        rm composer-setup.php
+        sudo php "$TMP_DIR/composer-setup.php" --quiet --install-dir=/usr/local/bin --filename=composer
+        rm "$TMP_DIR/composer-setup.php"
     else
         >&2 echo 'ERROR: Invalid installer checksum for Composer'
-        rm composer-setup.php
+        rm "$TMP_DIR/composer-setup.php"
     fi
 fi
 


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Predictable temporary file paths and downloading binaries to the current working directory. The `tools/os_installers/apt.sh` script downloaded files to locations like `/tmp/yq` or directly to `.` before using `sudo dpkg -i` or `sudo mv` on them. This creates a Time-of-Check to Time-of-Use (TOCTOU) vulnerability where a malicious user could pre-create a symlink at `/tmp/yq` pointing to a sensitive system file, or trick the script into overwriting local files, leading to privilege escalation when `sudo` is executed.
🎯 **Impact:** Local privilege escalation or denial of service by overwriting system binaries or arbitrary files owned by `root`.
🔧 **Fix:** Introduced a secure, isolated temporary directory using `TMP_DIR=$(mktemp -d)` at the start of the script. All vulnerable downloads (`go`, `yq`, `lsd`, `composer`) have been updated to target this secure directory. An `EXIT` trap was added to ensure the temporary directory is cleanly removed when the script finishes.
✅ **Verification:** Run `./build.sh syntax` to verify bash syntax. The script now safely downloads and cleans up artifacts without relying on shared, predictable directories. Also added a learning to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [2822382016456990647](https://jules.google.com/task/2822382016456990647) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced installer script security by implementing isolated temporary directories for all downloaded binaries and installation artifacts, replacing use of predictable system paths.

* **Documentation**
  * Added security vulnerability documentation detailing insecure temporary file handling patterns in setup scripts with prevention approaches and best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->