### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Insecure Temporary File Vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [Local Privilege Escalation in Installation Scripts]
+**Vulnerability:** Predictable temporary file paths (`/tmp/yq`) used during downloading executables, which were then processed with `sudo`.
+**Learning:** Hardcoding shared temporary directories (`/tmp`) allows local attackers to pre-create files or symlinks (TOCTOU attacks). This is especially critical when combined with `sudo` execution.
+**Prevention:** Always use securely generated, random temporary directories created by `mktemp -d` and paired with an `EXIT` trap for automated cleanup (e.g., `YQ_TMP_DIR=$(mktemp -d); trap "rm -rf '$YQ_TMP_DIR'" EXIT`).

--- a/tools/os_installers/apt.sh
+++ b/tools/os_installers/apt.sh
@@ -231,9 +231,13 @@ fi
 echo "Installing yq..."
 if ! command -v yq &> /dev/null; then
     YQ_VERSION="v4.44.6"
-    wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O /tmp/yq
-    sudo mv /tmp/yq /usr/local/bin/yq
+    YQ_TMP_DIR=$(mktemp -d)
+    # shellcheck disable=SC2064 # Trap will expand variable immediately, which is desired here
+    trap "rm -rf '$YQ_TMP_DIR'" EXIT
+    wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O "$YQ_TMP_DIR/yq"
+    sudo mv "$YQ_TMP_DIR/yq" /usr/local/bin/yq
     sudo chmod +x /usr/local/bin/yq
+    # Trap will clean up YQ_TMP_DIR when the script exits
 fi
 
 # Install lsd (LSDeluxe)


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Insecure Temporary File (CWE-377). The installation script used a predictable path (`/tmp/yq`) to download an executable, which was subsequently moved with `sudo` privileges. A local attacker could pre-create this file or symlink to escalate privileges or overwrite arbitrary system files (TOCTOU attack).
🎯 **Impact:** Local Privilege Escalation (LPE) or arbitrary file overwrite by any local user during the execution of the `apt.sh` installation script.
🔧 **Fix:** Replaced the hardcoded `/tmp/yq` path with a securely generated, restricted temporary directory using `mktemp -d`. Implemented an `EXIT` trap to guarantee cleanup of the temporary directory when the script finishes.
✅ **Verification:** Verified that `tools/os_installers/apt.sh` securely creates a directory with `mktemp -d` and utilizes the `EXIT` trap. The updated syntax was successfully validated via `shellcheck` (run through `./build.sh lint`).

---
*PR created automatically by Jules for task [2902433558536863833](https://jules.google.com/task/2902433558536863833) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced installation script security by implementing automatic cleanup and using securely generated temporary directories instead of predictable fixed paths.

* **Documentation**
  * Added documentation entry detailing a local privilege escalation vulnerability in installation scripts and recommended best practices for secure temporary directory handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->