### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in SSH key creation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2024-05-18 - [CRITICAL] Prevent TOCTOU vulnerabilities in file creation
+**Title:** Prevent TOCTOU vulnerabilities in file creation
+**Vulnerability:** Shell scripts creating files containing sensitive data (e.g., SSH private keys) and then calling `chmod 600` on them leave the files briefly readable based on the system's umask setting. This creates a Time-of-Check to Time-of-Use (TOCTOU) vulnerability where an attacker could read the sensitive data between file creation and the `chmod` operation.
+**Learning:** The default umask does not restrict file read access enough for sensitive files. Explicitly invoking `chmod` after creation is insufficient to protect sensitive data during that brief window.
+**Prevention:** Shell scripts handling sensitive data must enforce strict access control (permissions 600/700) using `umask 077` (globally or in a subshell) before file creation to prevent TOCTOU vulnerabilities.

--- a/tools/setup-ssh-keys.sh
+++ b/tools/setup-ssh-keys.sh
@@ -148,13 +148,18 @@ cmd_restore() {
 
     say "Restoring SSH key from 1Password..."
 
-    # Create SSH directory
-    mkdir -p "$SSH_DIR"
-    chmod 700 "$SSH_DIR"
+    # Use subshell with restricted umask to prevent TOCTOU vulnerability
+    (
+        umask 077
 
-    # Read private key from 1Password and save locally
-    op read "op://$VAULT/$KEY_NAME/private_key" > "$PRIVATE_KEY_FILE"
-    chmod 600 "$PRIVATE_KEY_FILE"
+        # Create SSH directory
+        mkdir -p "$SSH_DIR"
+        chmod 700 "$SSH_DIR"
+
+        # Read private key from 1Password and save locally
+        op read "op://$VAULT/$KEY_NAME/private_key" > "$PRIVATE_KEY_FILE"
+        chmod 600 "$PRIVATE_KEY_FILE"
+    )
 
     # Read public key from 1Password and save locally
     op read "op://$VAULT/$KEY_NAME/public_key" > "$PUBLIC_KEY_FILE"


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A Time-of-Check to Time-of-Use (TOCTOU) vulnerability where an SSH private key was created with default umask permissions before explicitly having `chmod 600` applied to it. This leaves a tiny window where the file is readable by other users.
🎯 **Impact:** Malicious actors or other users on the system could theoretically access the SSH private key during this brief, insecure creation phase.
🔧 **Fix:** Wrapped the file creation commands in a subshell applying a strict `umask 077` setting, enforcing restrictive 600 permissions immediately on creation before executing any `chmod`.
✅ **Verification:** Verified script correctness using `./build.sh lint` and bash syntax checker (`bash -n`). Added learning documentation to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [16881291364733891802](https://jules.google.com/task/16881291364733891802) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened SSH private key file protection during setup with improved permission enforcement.

* **Documentation**
  * Added security guidance for safe handling of sensitive files during creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->