### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix predictable temporary file path vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-04-04 - Predictable Temporary File Path Vulnerability in Package Download
+**Vulnerability:** A package install script (`tools/os_installers/apt.sh`) downloaded the `yq` binary to a hardcoded, predictable temporary file path (`/tmp/yq`) before moving it to its final destination with elevated privileges (`sudo mv`).
+**Learning:** Hardcoded temporary paths in shared directories (like `/tmp`) are vulnerable to Time-of-Check to Time-of-Use (TOCTOU) and symlink attacks, potentially allowing an attacker to overwrite arbitrary files or escalate privileges.
+**Prevention:** Always use securely generated random directories (e.g., `mktemp -d`) for temporary files. Wrap the temporary operations in a subshell `(...)` and use `trap 'rm -rf "$TMP_DIR"' EXIT` to ensure the directory is automatically and safely cleaned up, without overriding global script traps.

--- a/tools/os_installers/apt.sh
+++ b/tools/os_installers/apt.sh
@@ -231,9 +231,13 @@ fi
 echo "Installing yq..."
 if ! command -v yq &> /dev/null; then
     YQ_VERSION="v4.44.6"
-    wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O /tmp/yq
-    sudo mv /tmp/yq /usr/local/bin/yq
-    sudo chmod +x /usr/local/bin/yq
+    (
+        TMP_DIR=$(mktemp -d)
+        trap 'rm -rf "$TMP_DIR"' EXIT
+        wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O "$TMP_DIR/yq"
+        sudo mv "$TMP_DIR/yq" /usr/local/bin/yq
+        sudo chmod +x /usr/local/bin/yq
+    )
 fi
 
 # Install lsd (LSDeluxe)


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: A package installation script (`tools/os_installers/apt.sh`) previously downloaded the `yq` binary to a hardcoded, predictable temporary file path (`/tmp/yq`) before calling `sudo mv`. This setup exposes the system to Time-of-Check to Time-of-Use (TOCTOU) and symlink attacks, potentially leading to arbitrary file overwriting or local privilege escalation.
🎯 **Impact**: An attacker with local access could predict the path, overwrite `yq` before it is moved, and inject a malicious binary into `/usr/local/bin`, thereby executing arbitrary code with elevated privileges.
🔧 **Fix**: Modified the script to utilize `mktemp -d` within a subshell (`(...)`), ensuring the directory is created securely. Added `trap 'rm -rf "$TMP_DIR"' EXIT` for safe and localized cleanup without disrupting global traps.
✅ **Verification**:
- Verify that `tools/os_installers/apt.sh` no longer references `/tmp/yq`.
- Check that the `yq` installation uses `mktemp -d` within a subshell with proper traps.
- Ensure the repository passes validation checks (`./build.sh`).
- Verify `.jules/sentinel.md` has been updated with the corresponding security lesson.

---
*PR created automatically by Jules for task [10709256194709934029](https://jules.google.com/task/10709256194709934029) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a security vulnerability in the package installation process where temporary files were stored in a predictable location vulnerable to symlink attacks. The installer now uses securely generated temporary directories that are automatically cleaned up.

* **Documentation**
  * Added vulnerability documentation entry for tracking purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->