### PR TITLE
🛡️ Sentinel: [HIGH] Fix predictable /tmp path vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2024-04-05 - Predictable Temporary File Path in Installation Scripts
+
+**Vulnerability:** Predictable temporary file paths (`/tmp/yq`) are used for downloading files before moving them to privileged directories (`/usr/local/bin`) in `tools/os_installers/apt.sh`.
+**Learning:** Hardcoding a predictable file path in `/tmp` makes the script vulnerable to symlink attacks. An attacker could pre-create `/tmp/yq` as a symlink pointing to a sensitive file, causing the subsequent `sudo mv` command to overwrite the target file or potentially leading to arbitrary code execution if the downloaded binary is a payload that gets moved to a privileged path.
+**Prevention:** Always use secure, randomized temporary directories using `mktemp -d` when downloading or processing temporary files. Avoid hardcoding predictable file paths, especially when mixing unprivileged commands (`wget`) with privileged commands (`sudo`). Use a local cleanup trap inside a subshell for temporary directory removal.

--- a/tools/os_installers/apt.sh
+++ b/tools/os_installers/apt.sh
@@ -230,10 +230,14 @@ fi
 # Install yq
 echo "Installing yq..."
 if ! command -v yq &> /dev/null; then
-    YQ_VERSION="v4.44.6"
-    wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O /tmp/yq
-    sudo mv /tmp/yq /usr/local/bin/yq
-    sudo chmod +x /usr/local/bin/yq
+    (
+        TMP_DIR=$(mktemp -d)
+        trap 'rm -rf "$TMP_DIR"' EXIT
+        YQ_VERSION="v4.44.6"
+        wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O "$TMP_DIR/yq"
+        sudo mv "$TMP_DIR/yq" /usr/local/bin/yq
+        sudo chmod +x /usr/local/bin/yq
+    )
 fi
 
 # Install lsd (LSDeluxe)


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Predictable temporary file path (`/tmp/yq`) in `tools/os_installers/apt.sh` was used with a mixture of unprivileged (`wget`) and privileged (`sudo mv`) commands, creating a local privilege escalation/symlink attack vector.
🎯 **Impact:** A local attacker could pre-create a symlink at `/tmp/yq` pointing to an arbitrary sensitive file, causing it to be overwritten or compromised when the script runs.
🔧 **Fix:** Replaced the hardcoded path with a securely generated, randomized temporary directory using `mktemp -d`. The process is wrapped in a subshell with a localized `EXIT` trap to ensure reliable cleanup.
✅ **Verification:** Validated the updated script syntax using `./build.sh lint`. The updated installation process isolates the download and execution context cleanly.

---
*PR created automatically by Jules for task [12059556955293892260](https://jules.google.com/task/12059556955293892260) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened installation script security with enhanced temporary file and directory management procedures, improving protection during package installation and binary deployment processes.

* **Documentation**
  * Added new security vulnerability documentation detailing recent improvements and recommended mitigation strategies to enhance the safety of installation workflows and system updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->