### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix predictable temp file and CWD download vulnerabilities

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-04-07 - [Predictable Temp File & CWD Download Vulnerability in Installers]
+**Vulnerability:** Installation scripts (`apt.sh`) downloaded executables to predictable temporary paths (`/tmp/yq`) and directly to the current working directory.
+**Learning:** Using predictable paths like `/tmp/yq` without `mktemp` makes the script vulnerable to symlink attacks or pre-creation attacks, allowing an attacker to overwrite system files or escalate privileges when the script later calls `sudo mv`. Downloading directly to the CWD can lead to overwriting existing files or executing attacker-controlled binaries.
+**Prevention:** Always create isolated, randomly named temporary directories using `mktemp -d` inside a subshell `(...)` and clean them up automatically using a trap (e.g., `trap 'rm -rf "$TMP_DIR"' EXIT`). Download files strictly into this temporary directory.

--- a/tools/os_installers/apt.sh
+++ b/tools/os_installers/apt.sh
@@ -204,12 +204,15 @@ fi
 # Install Go
 echo "Installing Go..."
 if ! command -v go &> /dev/null; then
-    GO_VERSION="1.23.4"
-    wget "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz"
-    sudo rm -rf /usr/local/go
-    sudo tar -C /usr/local -xzf "go${GO_VERSION}.linux-amd64.tar.gz"
-    rm "go${GO_VERSION}.linux-amd64.tar.gz"
-    echo "NOTE: Add 'export PATH=\$PATH:/usr/local/go/bin' to your shell profile"
+    (
+        GO_VERSION="1.23.4"
+        TMP_DIR=$(mktemp -d)
+        trap 'rm -rf "$TMP_DIR"' EXIT
+        wget "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -O "$TMP_DIR/go.tar.gz"
+        sudo rm -rf /usr/local/go
+        sudo tar -C /usr/local -xzf "$TMP_DIR/go.tar.gz"
+        echo "NOTE: Add 'export PATH=\$PATH:/usr/local/go/bin' to your shell profile"
+    )
 fi
 
 # Install Terraform
@@ -230,19 +233,26 @@ fi
 # Install yq
 echo "Installing yq..."
 if ! command -v yq &> /dev/null; then
-    YQ_VERSION="v4.44.6"
-    wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O /tmp/yq
-    sudo mv /tmp/yq /usr/local/bin/yq
-    sudo chmod +x /usr/local/bin/yq
+    (
+        YQ_VERSION="v4.44.6"
+        TMP_DIR=$(mktemp -d)
+        trap 'rm -rf "$TMP_DIR"' EXIT
+        wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O "$TMP_DIR/yq"
+        sudo mv "$TMP_DIR/yq" /usr/local/bin/yq
+        sudo chmod +x /usr/local/bin/yq
+    )
 fi
 
 # Install lsd (LSDeluxe)
 echo "Installing lsd..."
 if ! command -v lsd &> /dev/null; then
-    LSD_VERSION="1.1.5"
-    wget "https://github.com/lsd-rs/lsd/releases/download/v${LSD_VERSION}/lsd_${LSD_VERSION}_amd64.deb"
-    sudo dpkg -i "lsd_${LSD_VERSION}_amd64.deb"
-    rm "lsd_${LSD_VERSION}_amd64.deb"
+    (
+        LSD_VERSION="1.1.5"
+        TMP_DIR=$(mktemp -d)
+        trap 'rm -rf "$TMP_DIR"' EXIT
+        wget "https://github.com/lsd-rs/lsd/releases/download/v${LSD_VERSION}/lsd_${LSD_VERSION}_amd64.deb" -O "$TMP_DIR/lsd.deb"
+        sudo dpkg -i "$TMP_DIR/lsd.deb"
+    )
 fi
 
 # Install Tesseract OCR


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix predictable temp file and CWD download vulnerabilities

**🚨 Severity:** CRITICAL
**💡 Vulnerability:** In `tools/os_installers/apt.sh`, executables were downloaded directly to the current working directory (`go.tar.gz`, `lsd.deb`) or to predictable temporary paths (`/tmp/yq`). 
**🎯 Impact:** Predictable temporary paths allow a local attacker to mount symlink or pre-creation attacks, enabling them to overwrite sensitive system files or escalate privileges when the script later executes `sudo mv` and `sudo chmod`. Downloading directly to the CWD can lead to overwriting existing files or accidentally executing attacker-controlled binaries in that directory.
**🔧 Fix:** Refactored the Go, yq, and lsd installation routines. Wrapped each in a subshell `(...)` and created an isolated, dynamically generated temporary directory using `mktemp -d`. Downloaded all binaries/archives safely into these temporary directories, and guaranteed their cleanup using `trap 'rm -rf "$TMP_DIR"' EXIT`. 
**✅ Verification:** Verified syntactical correctness and adherence to ShellCheck rules by successfully running `./build.sh` suite. The changes apply standard, robust Bash security patterns. Added the vulnerability and learning into `.jules/sentinel.md` journal.

---
*PR created automatically by Jules for task [6253691204747680482](https://jules.google.com/task/6253691204747680482) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Fixes**
  * Enhanced installer script security by using temporary isolated directories for tool downloads, preventing symlink and path-prediction attacks that could compromise system integrity.

* **Documentation**
  * Added a security advisory documenting installer vulnerabilities and recommended secure practices for file handling during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->