### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in ssh key restore

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-20 - TOCTOU Vulnerability in SSH Key Restoration
+**Vulnerability:** Time-of-Check to Time-of-Use (TOCTOU) when restoring SSH private keys from 1Password.
+**Learning:** Writing sensitive data to a file using default permissions and then using `chmod 600` leaves the file briefly readable by other users on the system between the write and the chmod.
+**Prevention:** Use a subshell with `umask 077` (e.g., `(umask 077 && command > file)`) to ensure the file is created with secure permissions (600) from the start.

--- a/tools/setup-ssh-keys.sh
+++ b/tools/setup-ssh-keys.sh
@@ -149,15 +149,15 @@ cmd_restore() {
     say "Restoring SSH key from 1Password..."
 
     # Create SSH directory
-    mkdir -p "$SSH_DIR"
+    (umask 077 && mkdir -p "$SSH_DIR")
     chmod 700 "$SSH_DIR"
 
     # Read private key from 1Password and save locally
-    op read "op://$VAULT/$KEY_NAME/private_key" > "$PRIVATE_KEY_FILE"
+    (umask 077 && op read "op://$VAULT/$KEY_NAME/private_key" > "$PRIVATE_KEY_FILE")
     chmod 600 "$PRIVATE_KEY_FILE"
 
     # Read public key from 1Password and save locally
-    op read "op://$VAULT/$KEY_NAME/public_key" > "$PUBLIC_KEY_FILE"
+    (umask 022 && op read "op://$VAULT/$KEY_NAME/public_key" > "$PUBLIC_KEY_FILE")
     chmod 644 "$PUBLIC_KEY_FILE"
 
     say "SSH key restored to $SSH_DIR"


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Time-of-Check to Time-of-Use (TOCTOU) vulnerability where SSH private keys are written with default permissions to the filesystem and then subsequently locked down with `chmod 600`. In the brief time interval between the creation of the file and the `chmod` command, the keys were readable by other users on the system (depending on the system `umask`).
🎯 Impact: Local privilege escalation / secret exposure to local attackers who could read the file before it was secured.
🔧 Fix: Wrapped the `op read` commands and `mkdir` inside subshells and set a safe umask `077` for the private key and directory, and `022` for the public key. This forces the system to create the file with the strict permissions right from the start.
✅ Verification: Ran `./build.sh` successfully and verified creation of `.jules/sentinel.md` logging the security learnings.

---
*PR created automatically by Jules for task [12850825814073710926](https://jules.google.com/task/12850825814073710926) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SSH key restoration now applies restrictive file permissions immediately upon creation.

* **Documentation**
  * Added documentation on SSH key file permission handling and security considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->