### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in SSH key generation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2026-04-10 - [TOCTOU vulnerability in SSH key generation]
+
+**Vulnerability:** Private SSH keys written to disk using shell redirection (`> "$PRIVATE_KEY_FILE"`) followed by `chmod 600`.
+**Learning:** Shell redirection creates the file according to the system's `umask`. If the `umask` allows, the file might briefly be readable by other users before `chmod 600` executes, causing a Time-of-Check to Time-of-Use (TOCTOU) vulnerability.
+**Prevention:** Wrap file creation steps that handle sensitive data in a subshell using `(umask 077 && command > file)` so that the file is created with secure permissions right from the start.

--- a/tools/setup-ssh-keys.sh
+++ b/tools/setup-ssh-keys.sh
@@ -153,7 +153,7 @@ cmd_restore() {
     chmod 700 "$SSH_DIR"
 
     # Read private key from 1Password and save locally
-    op read "op://$VAULT/$KEY_NAME/private_key" > "$PRIVATE_KEY_FILE"
+    (umask 077 && op read "op://$VAULT/$KEY_NAME/private_key" > "$PRIVATE_KEY_FILE")
     chmod 600 "$PRIVATE_KEY_FILE"
 
     # Read public key from 1Password and save locally


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The script created a private SSH key via redirection without specifying a `umask` prior, relying entirely on a `chmod 600` that came after creation. This causes a Time-of-Check to Time-of-Use (TOCTOU) vulnerability where the key may briefly be readable by other users.
🎯 Impact: Local Privilege Escalation or leakage of private SSH keys.
🔧 Fix: Wrapped the operation in a subshell using `umask 077` so the file is created with secure permissions right from the start.
✅ Verification: Tested against standard linting. Also updated Sentinel journal.

---
*PR created automatically by Jules for task [12923025182896873275](https://jules.google.com/task/12923025182896873275) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SSH private key generation now applies secure file permissions immediately during creation, preventing a potential security window.

* **Documentation**
  * Added security documentation identifying and documenting potential vulnerabilities in SSH key generation and recommended mitigations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->