### PR TITLE
🛡️ Sentinel: [HIGH] Fix insecure temporary file usage in apt.sh

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,15 @@
+# Sentinel Journal
+
+## 2024-04-11 - [Insecure Temporary File Usage for yq Download]
+
+**Vulnerability:** Predictable temporary file path `/tmp/yq` used during
+download and installation in `tools/os_installers/apt.sh`.
+
+**Learning:** Hardcoding `/tmp/yq` allows a malicious local user to pre-create
+`/tmp/yq` (e.g., as a symlink or with specific permissions), leading to potential
+privilege escalation or overriding of files when `sudo mv /tmp/yq ...` is
+executed.
+
+**Prevention:** Always use securely generated random directories like
+`mktemp -d` and wrap in a subshell with a cleanup trap to prevent local
+privilege escalation and symlink attacks.

--- a/tools/os_installers/apt.sh
+++ b/tools/os_installers/apt.sh
@@ -231,9 +231,13 @@ fi
 echo "Installing yq..."
 if ! command -v yq &> /dev/null; then
     YQ_VERSION="v4.44.6"
-    wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O /tmp/yq
-    sudo mv /tmp/yq /usr/local/bin/yq
-    sudo chmod +x /usr/local/bin/yq
+    (
+        TMP_DIR=$(mktemp -d)
+        trap 'rm -rf "$TMP_DIR"' EXIT
+        wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O "$TMP_DIR/yq"
+        sudo mv "$TMP_DIR/yq" /usr/local/bin/yq
+        sudo chmod +x /usr/local/bin/yq
+    )
 fi
 
 # Install lsd (LSDeluxe)


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix insecure temporary file usage in apt.sh

🚨 Severity: HIGH
💡 Vulnerability: Predictable temporary file path `/tmp/yq` used during the download and installation of `yq`.
🎯 Impact: Hardcoding `/tmp/yq` allows a malicious local user to pre-create `/tmp/yq` (e.g., as a symlink or with specific permissions), leading to potential privilege escalation or overriding of arbitrary files when `sudo mv /tmp/yq /usr/local/bin/yq` is executed.
🔧 Fix: Replaced the hardcoded `/tmp/yq` download and move logic with a subshell that creates a secure temporary directory using `mktemp -d` and implements an `EXIT` trap to guarantee cleanup.
✅ Verification: Ran `./build.sh` (ShellCheck passed) and reviewed the patch.

---
*PR created automatically by Jules for task [7306839158455040801](https://jules.google.com/task/7306839158455040801) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a local privilege escalation vulnerability in the package installer that used predictable temporary file locations, exploitable by attackers on the same system.

* **Documentation**
  * Added security incident records documenting the vulnerability details and prevention guidance for similar issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->