### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in SSH key creation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,15 @@
+# Sentinel Journal
+
+## 2026-04-15 - Prevent TOCTOU in SSH Key Restoration
+
+**Vulnerability:** A Time-of-Check to Time-of-Use (TOCTOU) vulnerability where an
+SSH private key is briefly world-readable upon creation before `chmod 600` is
+applied.
+
+**Learning:** Redirecting output to a file creates the file with default
+permissions (often `644`), which exposes sensitive data for a fraction of a
+second.
+
+**Prevention:** Wrap commands that create sensitive files in a subshell using
+`umask 077` to ensure the file is created with secure permissions (`600`)
+natively.

--- a/tools/setup-ssh-keys.sh
+++ b/tools/setup-ssh-keys.sh
@@ -153,7 +153,7 @@ cmd_restore() {
     chmod 700 "$SSH_DIR"
 
     # Read private key from 1Password and save locally
-    op read "op://$VAULT/$KEY_NAME/private_key" > "$PRIVATE_KEY_FILE"
+    (umask 077 && op read "op://$VAULT/$KEY_NAME/private_key" > "$PRIVATE_KEY_FILE")
     chmod 600 "$PRIVATE_KEY_FILE"
 
     # Read public key from 1Password and save locally


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Time-of-Check to Time-of-Use (TOCTOU) vulnerability where an SSH private key is created via shell redirection with default permissions (often `644`) before a subsequent `chmod 600` is executed, making it briefly world-readable.
🎯 **Impact:** A malicious local process could potentially read the highly sensitive private SSH key during the brief window before its permissions are restricted, leading to unauthorized access.
🔧 **Fix:** Wrapped the file creation command (`op read ... > "$PRIVATE_KEY_FILE"`) in a subshell using `umask 077` so the file is inherently created with secure permissions (`600`).
✅ **Verification:** Verify by running `./build.sh` to ensure shellcheck passes. The `.jules/sentinel.md` journal has also been updated with this learning and validated via markdownlint.

---
*PR created automatically by Jules for task [11118521380977216829](https://jules.google.com/task/11118521380977216829) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced restrictive permissions immediately when creating/restoring SSH private keys to eliminate a brief exposure window.

* **Documentation**
  * Added a security journal entry detailing secure SSH key permission handling and recommended commands to avoid temporary key exposure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->