### PR TITLE
🛡️ Sentinel: [HIGH] Fix insecure temporary download paths in apt.sh

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,16 @@
+# Sentinel Security Journal
+
+## 2026-04-16 - Prevent TOCTOU and Symlink Attacks via Insecure Temporary Directories
+
+**Vulnerability:** Shell scripts were downloading executable artifacts directly
+to predictable temporary paths like `/tmp/yq` or the current working directory,
+which risks local privilege escalation, symlink attacks, and overwriting
+existing files when executed with elevated privileges (`sudo`).
+**Learning:** Hardcoded temporary paths (`/tmp/...`) are insecure and
+susceptible to symlink hijacking by local attackers. Additionally, downloading
+directly to the current directory is poor practice and pollutes the workspace
+or risks naming collisions.
+**Prevention:** Always use securely generated random directories (e.g.,
+`TMP_DIR=$(mktemp -d)`) wrapped in a subshell `(...)` and paired with a local
+trap (`trap 'rm -rf "$TMP_DIR"' EXIT`) to ensure isolation and automatic
+cleanup upon exit.

--- a/tools/os_installers/apt.sh
+++ b/tools/os_installers/apt.sh
@@ -204,12 +204,15 @@ fi
 # Install Go
 echo "Installing Go..."
 if ! command -v go &> /dev/null; then
-    GO_VERSION="1.23.4"
-    wget "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz"
-    sudo rm -rf /usr/local/go
-    sudo tar -C /usr/local -xzf "go${GO_VERSION}.linux-amd64.tar.gz"
-    rm "go${GO_VERSION}.linux-amd64.tar.gz"
-    echo "NOTE: Add 'export PATH=\$PATH:/usr/local/go/bin' to your shell profile"
+    (
+        TMP_DIR=$(mktemp -d)
+        trap 'rm -rf "$TMP_DIR"' EXIT
+        GO_VERSION="1.23.4"
+        wget "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -O "$TMP_DIR/go${GO_VERSION}.linux-amd64.tar.gz"
+        sudo rm -rf /usr/local/go
+        sudo tar -C /usr/local -xzf "$TMP_DIR/go${GO_VERSION}.linux-amd64.tar.gz"
+        echo "NOTE: Add 'export PATH=\$PATH:/usr/local/go/bin' to your shell profile"
+    )
 fi
 
 # Install Terraform
@@ -230,19 +233,26 @@ fi
 # Install yq
 echo "Installing yq..."
 if ! command -v yq &> /dev/null; then
-    YQ_VERSION="v4.44.6"
-    wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O /tmp/yq
-    sudo mv /tmp/yq /usr/local/bin/yq
-    sudo chmod +x /usr/local/bin/yq
+    (
+        TMP_DIR=$(mktemp -d)
+        trap 'rm -rf "$TMP_DIR"' EXIT
+        YQ_VERSION="v4.44.6"
+        wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O "$TMP_DIR/yq"
+        sudo mv "$TMP_DIR/yq" /usr/local/bin/yq
+        sudo chmod +x /usr/local/bin/yq
+    )
 fi
 
 # Install lsd (LSDeluxe)
 echo "Installing lsd..."
 if ! command -v lsd &> /dev/null; then
-    LSD_VERSION="1.1.5"
-    wget "https://github.com/lsd-rs/lsd/releases/download/v${LSD_VERSION}/lsd_${LSD_VERSION}_amd64.deb"
-    sudo dpkg -i "lsd_${LSD_VERSION}_amd64.deb"
-    rm "lsd_${LSD_VERSION}_amd64.deb"
+    (
+        TMP_DIR=$(mktemp -d)
+        trap 'rm -rf "$TMP_DIR"' EXIT
+        LSD_VERSION="1.1.5"
+        wget "https://github.com/lsd-rs/lsd/releases/download/v${LSD_VERSION}/lsd_${LSD_VERSION}_amd64.deb" -O "$TMP_DIR/lsd_${LSD_VERSION}_amd64.deb"
+        sudo dpkg -i "$TMP_DIR/lsd_${LSD_VERSION}_amd64.deb"
+    )
 fi
 
 # Install Tesseract OCR


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `tools/os_installers/apt.sh` script was downloading executable artifacts to predictable temporary paths like `/tmp/yq` or directly to the current working directory. This pattern is vulnerable to Time-of-Check to Time-of-Use (TOCTOU) and symlink attacks. If an attacker pre-creates a symlink at `/tmp/yq` pointing to a sensitive file, the script (running with `sudo`) could inadvertently overwrite it or allow local privilege escalation.
🎯 Impact: Local attackers could potentially escalate privileges or overwrite critical system files by exploiting the predictable download paths when the installation script is executed.
🔧 Fix: Wrapped the `go`, `yq`, and `lsd` installation blocks in subshells `(...)`. Within each subshell, a secure temporary directory is created using `TMP_DIR=$(mktemp -d)`, and a local trap (`trap 'rm -rf "$TMP_DIR"' EXIT`) ensures cleanup. The `wget` commands were updated to download specifically into this isolated directory.
✅ Verification: Ensure the scripts pass `shellcheck` (via `./build.sh lint`) and that running the modified installation blocks does not leave artifacts in `/tmp` or the current directory.

---
*PR created automatically by Jules for task [10068104001288958326](https://jules.google.com/task/10068104001288958326) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security journal entry documenting temporary file handling patterns for shell scripts

* **Chores**
  * Updated package installer to use dynamically-created temporary directories for artifact downloads and processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->