### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure temporary files in apt.sh

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,17 @@
+# Sentinel Security Journal
+
+## 2025-04-17 - Insecure Temporary Files and Direct Downloads in Installation Scripts
+
+**Vulnerability:** Predictable temporary files and direct downloads to the
+current working directory in `tools/os_installers/apt.sh`.
+
+**Learning:** Installation scripts often download artifacts. Using predictable
+paths like `/tmp/yq` allows local attackers to overwrite or predict the file,
+leading to potential privilege escalation (especially since the script uses
+`sudo`). Additionally, downloading archives directly to the current working
+directory is an insecure practice as it risks overwriting existing files or
+leaving artifacts behind.
+
+**Prevention:** Always use securely generated temporary directories via
+`mktemp -d` within a subshell, and use a `trap 'rm -rf "$TMP_DIR"' EXIT` for
+safe cleanup, rather than predictable paths or the current directory.

--- a/tools/os_installers/apt.sh
+++ b/tools/os_installers/apt.sh
@@ -205,11 +205,14 @@ fi
 echo "Installing Go..."
 if ! command -v go &> /dev/null; then
     GO_VERSION="1.23.4"
-    wget "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz"
-    sudo rm -rf /usr/local/go
-    sudo tar -C /usr/local -xzf "go${GO_VERSION}.linux-amd64.tar.gz"
-    rm "go${GO_VERSION}.linux-amd64.tar.gz"
-    echo "NOTE: Add 'export PATH=\$PATH:/usr/local/go/bin' to your shell profile"
+    (
+        TMP_DIR=$(mktemp -d)
+        trap 'rm -rf "$TMP_DIR"' EXIT
+        wget "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -O "$TMP_DIR/go.tar.gz"
+        sudo rm -rf /usr/local/go
+        sudo tar -C /usr/local -xzf "$TMP_DIR/go.tar.gz"
+        echo "NOTE: Add 'export PATH=\$PATH:/usr/local/go/bin' to your shell profile"
+    )
 fi
 
 # Install Terraform
@@ -231,18 +234,25 @@ fi
 echo "Installing yq..."
 if ! command -v yq &> /dev/null; then
     YQ_VERSION="v4.44.6"
-    wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O /tmp/yq
-    sudo mv /tmp/yq /usr/local/bin/yq
-    sudo chmod +x /usr/local/bin/yq
+    (
+        TMP_DIR=$(mktemp -d)
+        trap 'rm -rf "$TMP_DIR"' EXIT
+        wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O "$TMP_DIR/yq"
+        sudo mv "$TMP_DIR/yq" /usr/local/bin/yq
+        sudo chmod +x /usr/local/bin/yq
+    )
 fi
 
 # Install lsd (LSDeluxe)
 echo "Installing lsd..."
 if ! command -v lsd &> /dev/null; then
     LSD_VERSION="1.1.5"
-    wget "https://github.com/lsd-rs/lsd/releases/download/v${LSD_VERSION}/lsd_${LSD_VERSION}_amd64.deb"
-    sudo dpkg -i "lsd_${LSD_VERSION}_amd64.deb"
-    rm "lsd_${LSD_VERSION}_amd64.deb"
+    (
+        TMP_DIR=$(mktemp -d)
+        trap 'rm -rf "$TMP_DIR"' EXIT
+        wget "https://github.com/lsd-rs/lsd/releases/download/v${LSD_VERSION}/lsd_${LSD_VERSION}_amd64.deb" -O "$TMP_DIR/lsd.deb"
+        sudo dpkg -i "$TMP_DIR/lsd.deb"
+    )
 fi
 
 # Install Tesseract OCR


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Predictable temporary files (`/tmp/yq`) and direct downloads (`wget` to current directory) in `tools/os_installers/apt.sh`.
🎯 **Impact:** Local privilege escalation via symlink attacks (because `sudo mv` is used on a world-writable predictable path) and potential overwriting of existing files or leaving unnecessary artifacts in the user's directory.
🔧 **Fix:** Refactored the `yq`, `go`, and `lsd` installation blocks to use securely generated, randomly named temporary directories (`mktemp -d`) within a subshell, combined with an `EXIT` trap for automatic, safe cleanup.
✅ **Verification:** Verified by inspecting `tools/os_installers/apt.sh` to confirm the use of `mktemp -d`, subshells, and traps, and by running the `./build.sh` suite to ensure syntax and markdown linting pass. A journal entry was also created in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [18063684518302147309](https://jules.google.com/task/18063684518302147309) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security of the installation process for Go, yq, and lsd by implementing safer temporary file handling mechanisms.

* **Documentation**
  * Added security guidelines documenting best practices for safe temporary file handling in installation scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->