### PR TITLE
🛡️ Sentinel: [security improvement] Secure composer-setup.php download with mktemp

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -13,7 +13,6 @@ second.
 **Prevention:** Wrap commands that create sensitive files in a subshell using
 `umask 077` to ensure the file is created with secure permissions (`600`)
 natively.
-# Sentinel Security Journal
 
 ## 2026-04-16 - Prevent TOCTOU and Symlink Attacks via Insecure Temporary Directories
 
@@ -29,3 +28,17 @@ or risks naming collisions.
 `TMP_DIR=$(mktemp -d)`) wrapped in a subshell `(...)` and paired with a local
 trap (`trap 'rm -rf "$TMP_DIR"' EXIT`) to ensure isolation and automatic
 cleanup upon exit.
+
+## 2026-04-20 - Insecure executable artifact download location
+
+**Vulnerability:** Downloaded executable script (`composer-setup.php`) directly
+to the current working directory in an installation script.
+
+**Learning:** Downloading files directly to the current directory is insecure
+because it might overwrite existing files or leave executable artifacts
+susceptible to modification before execution, especially in scripts that may run
+with elevated privileges.
+
+**Prevention:** Always use securely generated isolated temporary directories via
+`mktemp -d`, and wrap the setup in a subshell `(...)` with an automatic `trap`
+to ensure secure handling and cleanup.

--- a/tools/os_installers/apt.sh
+++ b/tools/os_installers/apt.sh
@@ -262,17 +262,19 @@ sudo apt install -y tesseract-ocr
 # Install PHP Composer
 echo "Installing Composer..."
 if ! command -v composer &> /dev/null; then
-    EXPECTED_CHECKSUM="$(php -r 'copy("https://composer.github.io/installer.sig", "php://stdout");')"
-    php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-    ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
+    (
+        TMP_DIR=$(mktemp -d)
+        trap 'rm -rf "$TMP_DIR"' EXIT
+        EXPECTED_CHECKSUM="$(php -r 'copy("https://composer.github.io/installer.sig", "php://stdout");')"
+        php -r "copy('https://getcomposer.org/installer', '$TMP_DIR/composer-setup.php');"
+        ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', '$TMP_DIR/composer-setup.php');")"
 
-    if [ "$EXPECTED_CHECKSUM" = "$ACTUAL_CHECKSUM" ]; then
-        sudo php composer-setup.php --quiet --install-dir=/usr/local/bin --filename=composer
-        rm composer-setup.php
-    else
-        >&2 echo 'ERROR: Invalid installer checksum for Composer'
-        rm composer-setup.php
-    fi
+        if [ "$EXPECTED_CHECKSUM" = "$ACTUAL_CHECKSUM" ]; then
+            sudo php "$TMP_DIR/composer-setup.php" --quiet --install-dir=/usr/local/bin --filename=composer
+        else
+            >&2 echo 'ERROR: Invalid installer checksum for Composer'
+        fi
+    )
 fi
 
 # Clean up


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Downloaded executable script (`composer-setup.php`) directly to the current working directory in an installation script.
🎯 Impact: Downloading files directly to the current directory is insecure because it might overwrite existing files or leave executable artifacts susceptible to modification before execution, especially in scripts that may run with elevated privileges.
🔧 Fix: Wrapped the operation in a subshell `(...)` and used `mktemp -d` to create an isolated temporary directory, paired with an automatic `trap` to ensure secure handling and cleanup.
✅ Verification: Ran `./build.sh` successfully and validated the Sentinel journal markdown structure.

---
*PR created automatically by Jules for task [5157817558690188543](https://jules.google.com/task/5157817558690188543) started by @kidchenko*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the Composer installer security by downloading setup files to temporary directories instead of the current working directory, with automatic cleanup on completion.

* **Documentation**
  * Added security documentation outlining best practices for temporary file handling, isolation, and cleanup procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->